### PR TITLE
IBM doc contains garbage in some cells, potential to crash parse of unload records

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="pyracf",
-    version="0.6.6",
+    version="0.7.0",
     author="Wizard of z/OS",
     author_email="wizard@zdevops.com",
     description="Parsing IRRDBU00 unloads in panda dataframes.",

--- a/src/pyracf/__init__.py
+++ b/src/pyracf/__init__.py
@@ -156,7 +156,7 @@ class RACF:
             speed  = math.floor(seen/((self._stoptime - self._starttime).total_seconds()))
             parsetime = (self._stoptime - self._starttime).total_seconds()
         else:
-            self._state == "Limbo"     
+            status = "Limbo"     
         return {'status': status, 'input-lines': self._unloadlines, 'lines-read': seen, 'lines-parsed': parsed, 'lines-per-second': speed, 'parse-time': parsetime}
 
     def parse_fancycli(self, recordtypes=_recordtype_info.keys(), save_pickles=False, prefix=''):

--- a/src/pyracf/__init__.py
+++ b/src/pyracf/__init__.py
@@ -25,17 +25,17 @@ class StoopidException(Exception):
         super().__init__(self.message)
 
 def deprecated(func,oldname):
-    ''' Wrapper routine to add (old) alias name to new routine (func), supports methods and properties. 
+    ''' Wrapper routine to add (deprecated) alias name to new routine (func), supports methods and properties. 
         Inspired by functools.partial() '''
-    def newfunc(*arg,**keywords):
+    def deprecated_func(*arg,**keywords):
         if hasattr(func,"__name__"):  # normal function object
             newroutine = func
         else:  # property object
             newroutine = func.fget
         warnings.warn(f"{oldname} is deprecated and will be removed, use {newroutine.__name__} instead.")
         return newroutine(*arg,**keywords)
-    newfunc.func = func
-    return newfunc
+    deprecated_func.func = func
+    return deprecated_func
 
 class RACF:
     

--- a/src/pyracf/offsets.json
+++ b/src/pyracf/offsets.json
@@ -1,5 +1,5 @@
 {
-    "Group basic data record ": {
+    "group-basic-data-record": {
         "record-type": "0100",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/format.htm",
         "offsets": [
@@ -43,14 +43,14 @@
                 "type": "Char",
                 "start": "44",
                 "end": "51",
-                "field-desc": null
+                "field-desc": "The default universal access. Valid values are "
             },
             {
                 "field-name": "GPBD_NOTERMUACC",
                 "type": "Char",
                 "start": "53",
                 "end": "56",
-                "field-desc": "Indicates if the group must be specifically authorized\nto use a particular terminal through the use of the PERMIT command.\nValid Values include \"Yes\" and \"No\"."
+                "field-desc": "Indicates if the group must be specifically authorized to use a particular terminal through the use of the PERMIT command. Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GPBD_INSTALL_DATA",
@@ -64,18 +64,18 @@
                 "type": "Char",
                 "start": "314",
                 "end": "357",
-                "field-desc": "Data set profile that is used as a model for this\ngroup."
+                "field-desc": "Data set profile that is used as a model for this group."
             },
             {
                 "field-name": "GPBD_UNIVERSAL",
                 "type": "Char",
                 "start": "359",
                 "end": "362",
-                "field-desc": "Indicates if the group has the UNIVERSAL attribute.\nValid Values include \"Yes\" and \"No\"."
+                "field-desc": "Indicates if the group has the UNIVERSAL attribute. Valid Values include \"Yes\" and \"No\"."
             }
         ]
     },
-    "Group subgroups record ": {
+    "group-subgroups-record": {
         "record-type": "0101",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/format.htm",
         "offsets": [
@@ -102,7 +102,7 @@
             }
         ]
     },
-    "Group members record ": {
+    "group-members-record": {
         "record-type": "0102",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/format.htm",
         "offsets": [
@@ -132,11 +132,11 @@
                 "type": "Char",
                 "start": "24",
                 "end": "31",
-                "field-desc": null
+                "field-desc": "Indicates the authority that the user ID has within the group. Valid values are "
             }
         ]
     },
-    "Group installation data record ": {
+    "group-installation-data-record": {
         "record-type": "0103",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/format.htm",
         "offsets": [
@@ -145,7 +145,7 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the Group Installation Data record\n(0103)."
+                "field-desc": "Record type of the Group Installation Data record (0103)."
             },
             {
                 "field-name": "GPINSTD_NAME",
@@ -173,11 +173,11 @@
                 "type": "Char",
                 "start": "280",
                 "end": "287",
-                "field-desc": null
+                "field-desc": "The flag for the installation-defined field in the form "
             }
         ]
     },
-    "Group DFP data record ": {
+    "group-dfp-data-record": {
         "record-type": "0110",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/format.htm",
         "offsets": [
@@ -225,7 +225,7 @@
             }
         ]
     },
-    "Group OMVS data record ": {
+    "group-omvs-data-record": {
         "record-type": "0120",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/format.htm",
         "offsets": [
@@ -248,11 +248,11 @@
                 "type": "Char",
                 "start": "15",
                 "end": "24",
-                "field-desc": null
+                "field-desc": "OMVS "
             }
         ]
     },
-    "Group OVM data record ": {
+    "group-ovm-data-record": {
         "record-type": "0130",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/format.htm",
         "offsets": [
@@ -275,11 +275,11 @@
                 "type": "Char",
                 "start": "15",
                 "end": "24",
-                "field-desc": "OpenExtensions group identifier (GID) associated\nwith the group name from the profile."
+                "field-desc": "OpenExtensions group identifier (GID) associated with the group name from the profile."
             }
         ]
     },
-    "Group TME role record ": {
+    "group-tme-role-record": {
         "record-type": "0141",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/format.htm",
         "offsets": [
@@ -306,7 +306,7 @@
             }
         ]
     },
-    "Group CSDATA custom fields record ": {
+    "group-csdata-custom-fields-record": {
         "record-type": "0151",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/format.htm",
         "offsets": [
@@ -315,7 +315,7 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the Group CSDATA custom fields\n(0151)."
+                "field-desc": "Record type of the Group CSDATA custom fields (0151)."
             },
             {
                 "field-name": "GPCSD_NAME",
@@ -329,7 +329,7 @@
                 "type": "Char",
                 "start": "15",
                 "end": "18",
-                "field-desc": "Data type for the custom field. Valid values are\nCHAR, FLAG, HEX, NUM."
+                "field-desc": "Data type for the custom field. Valid values are CHAR, FLAG, HEX, NUM."
             },
             {
                 "field-name": "GPCSD_KEY",
@@ -347,7 +347,7 @@
             }
         ]
     },
-    "User basic data record ": {
+    "user-basic-data-record": {
         "record-type": "0200",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -384,42 +384,42 @@
                 "type": "Char",
                 "start": "35",
                 "end": "38",
-                "field-desc": "Does the user have the ADSP attribute? Valid Values\ninclude \"Yes\" and \"No\"."
+                "field-desc": "Does the user have the ADSP attribute? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USBD_SPECIAL",
                 "type": "Char",
                 "start": "40",
                 "end": "43",
-                "field-desc": "Does the user have the SPECIAL attribute? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Does the user have the SPECIAL attribute? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USBD_OPER",
                 "type": "Char",
                 "start": "45",
                 "end": "48",
-                "field-desc": "Does the user have the OPERATIONS attribute? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Does the user have the OPERATIONS attribute? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USBD_REVOKE",
                 "type": "Char",
                 "start": "50",
                 "end": "53",
-                "field-desc": "Is the user REVOKEd? Valid Values include \"Yes\"\nand \"No\"."
+                "field-desc": "Is the user REVOKEd? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USBD_GRPACC",
                 "type": "Char",
                 "start": "55",
                 "end": "58",
-                "field-desc": "Does the user have the GRPACC attribute? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Does the user have the GRPACC attribute? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USBD_PWD_INTERVAL",
                 "type": "Int",
                 "start": "60",
                 "end": "62",
-                "field-desc": "The number of days that the user's password can\nbe used."
+                "field-desc": "The number of days that the user's password can be used."
             },
             {
                 "field-name": "USBD_PWD_DATE",
@@ -447,14 +447,14 @@
                 "type": "Time",
                 "start": "105",
                 "end": "112",
-                "field-desc": "The last recorded time that the user entered the\nsystem."
+                "field-desc": "The last recorded time that the user entered the system."
             },
             {
                 "field-name": "USBD_LASTJOB_DATE",
                 "type": "Date",
                 "start": "114",
                 "end": "123",
-                "field-desc": "The last recorded date that the user entered the\nsystem."
+                "field-desc": "The last recorded date that the user entered the system."
             },
             {
                 "field-name": "USBD_INSTALL_DATA",
@@ -468,28 +468,28 @@
                 "type": "Char",
                 "start": "381",
                 "end": "384",
-                "field-desc": "Do all RACHECK and RACDEF SVCs cause logging?\nValid Values include \"Yes\" and \"No\"."
+                "field-desc": "Do all RACHECK and RACDEF SVCs cause logging? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USBD_AUDITOR",
                 "type": "Char",
                 "start": "386",
                 "end": "389",
-                "field-desc": "Does this user have the AUDITOR attribute? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Does this user have the AUDITOR attribute? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USBD_NOPWD",
                 "type": "Char",
                 "start": "391",
                 "end": "394",
-                "field-desc": null
+                "field-desc": "\"YES\" indicates that this user ID can log on without a password using OID card. \"NO\" indicates that this user must specify a password. \"PRO\" indicates a protected user ID. \"PHR\" indicates that the user has a password phrase."
             },
             {
                 "field-name": "USBD_OIDCARD",
                 "type": "Char",
                 "start": "396",
                 "end": "399",
-                "field-desc": "Does this user have OIDCARD data? Valid Values\ninclude \"Yes\" and \"No\"."
+                "field-desc": "Does this user have OIDCARD data? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USBD_PWD_GEN",
@@ -538,49 +538,49 @@
                 "type": "Char",
                 "start": "480",
                 "end": "483",
-                "field-desc": "Can the user access the system on Sunday? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Can the user access the system on Sunday? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USBD_ACCESS_MON",
                 "type": "Char",
                 "start": "485",
                 "end": "488",
-                "field-desc": "Can the user access the system on Monday? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Can the user access the system on Monday? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USBD_ACCESS_TUE",
                 "type": "Char",
                 "start": "490",
                 "end": "493",
-                "field-desc": "Can the user access the system on Tuesday? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Can the user access the system on Tuesday? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USBD_ACCESS_WED",
                 "type": "Char",
                 "start": "495",
                 "end": "498",
-                "field-desc": "Can the user access the system on Wednesday? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Can the user access the system on Wednesday? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USBD_ACCESS_THU",
                 "type": "Char",
                 "start": "500",
                 "end": "503",
-                "field-desc": "Can the user access the system on Thursday? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Can the user access the system on Thursday? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USBD_ACCESS_FRI",
                 "type": "Char",
                 "start": "505",
                 "end": "508",
-                "field-desc": "Can the user access the system on Friday? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Can the user access the system on Friday? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USBD_ACCESS_SAT",
                 "type": "Char",
                 "start": "510",
                 "end": "513",
-                "field-desc": "Can the user access the system on Saturday? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Can the user access the system on Saturday? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USBD_START_TIME",
@@ -608,21 +608,21 @@
                 "type": "Char",
                 "start": "542",
                 "end": "549",
-                "field-desc": "Other user attributes (RSTD for users with RESTRICTED\nattribute)."
+                "field-desc": "Other user attributes (RSTD for users with RESTRICTED attribute)."
             },
             {
                 "field-name": "USBD_PWDENV_EXISTS",
                 "type": "Char",
                 "start": "551",
                 "end": "554",
-                "field-desc": "Has a PKCS#7 envelope been created for the user's\ncurrent password? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Has a PKCS#7 envelope been created for the user's current password? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USBD_PWD_ASIS",
                 "type": "Char",
                 "start": "556",
                 "end": "559",
-                "field-desc": "Should the password be evaluated in the case\nentered? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Should the password be evaluated in the case entered? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USBD_PHR_DATE",
@@ -643,21 +643,21 @@
                 "type": "Int",
                 "start": "576",
                 "end": "585",
-                "field-desc": "Sequence number that is incremented whenever\na certificate for the user is added, deleted, or altered. The starting\nvalue might not be 0."
+                "field-desc": "Sequence number that is incremented whenever a certificate for the user is added, deleted, or altered. The starting value might not be 0."
             },
             {
                 "field-name": "USBD_PPHENV_EXISTS",
                 "type": "Char",
                 "start": "587",
                 "end": "590",
-                "field-desc": "Has the user's current password phrase been\nPKCS#7 enveloped for possible retrieval? Valid Values include \"Yes\"\nand \"No\"."
+                "field-desc": "Has the user's current password phrase been PKCS#7 enveloped for possible retrieval? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USBD_PWD_ALG",
                 "type": "Char",
                 "start": "592",
                 "end": "603",
-                "field-desc": "Algorithm that is used to protect passwords.\n Possible values are \"LEGACY\", \"KDFAES\", and \"NOPASSWORD\"."
+                "field-desc": "Algorithm that is used to protect passwords.  Possible values are \"LEGACY\", \"KDFAES\", and \"NOPASSWORD\"."
             },
             {
                 "field-name": "USBD_LEG_PWDHIST_CT",
@@ -678,7 +678,7 @@
                 "type": "Char",
                 "start": "613",
                 "end": "624",
-                "field-desc": "Algorithm that is used to protect password phrases.\n Possible values are \"LEGACY\", \"KDFAES\", and \"NOPHRASE\"."
+                "field-desc": "Algorithm that is used to protect password phrases.  Possible values are \"LEGACY\", \"KDFAES\", and \"NOPHRASE\"."
             },
             {
                 "field-name": "USBD_LEG_PHRHIST_CT",
@@ -699,25 +699,25 @@
                 "type": "Char",
                 "start": "634",
                 "end": "637",
-                "field-desc": "This user can have a ROAUDIT attribute. Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "This user can have a ROAUDIT attribute. Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USBD_MFA_FALLBACK",
                 "type": "Char",
                 "start": "639",
                 "end": "641",
-                "field-desc": "This user can use a password or password phrase to logon to the system when\nMFA is unavailable. Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "This user can use a password or password phrase to logon to the system when MFA is unavailable. Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USBD_PHR_INTERVAL",
                 "type": "Char",
                 "start": "644",
                 "end": "648",
-                "field-desc": null
+                "field-desc": "The number of days that the user's password phrase can be used."
             }
         ]
     },
-    "User categories record ": {
+    "user-categories-record": {
         "record-type": "0201",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -744,7 +744,7 @@
             }
         ]
     },
-    "User classes record ": {
+    "user-classes-record": {
         "record-type": "0202",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -767,11 +767,11 @@
                 "type": "Char",
                 "start": "15",
                 "end": "22",
-                "field-desc": "A class in which the user is allowed to define\nprofiles."
+                "field-desc": "A class in which the user is allowed to define profiles."
             }
         ]
     },
-    "User group connections record ": {
+    "user-group-connections-record": {
         "record-type": "0203",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -780,7 +780,7 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the User Group Connections record\n(0203)."
+                "field-desc": "Record type of the User Group Connections record (0203)."
             },
             {
                 "field-name": "USGCON_NAME",
@@ -798,7 +798,7 @@
             }
         ]
     },
-    "User installation data record ": {
+    "user-installation-data-record": {
         "record-type": "0204",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -807,7 +807,7 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the User Installation Data record\n(0204)."
+                "field-desc": "Record type of the User Installation Data record (0204)."
             },
             {
                 "field-name": "USINSTD_NAME",
@@ -835,11 +835,11 @@
                 "type": "Char",
                 "start": "280",
                 "end": "287",
-                "field-desc": null
+                "field-desc": "The flag for the installation-defined field in the form "
             }
         ]
     },
-    "User connect data record ": {
+    "user-connect-data-record": {
         "record-type": "0205",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -897,81 +897,81 @@
                 "type": "Char",
                 "start": "64",
                 "end": "71",
-                "field-desc": null
+                "field-desc": "The default universal access authority for all new resources the user defines while connected to the specified group. Valid values are "
             },
             {
                 "field-name": "USCON_INIT_CNT",
                 "type": "Int",
                 "start": "73",
                 "end": "77",
-                "field-desc": "The number of RACINITs issued for this user/group\ncombination."
+                "field-desc": "The number of RACINITs issued for this user/group combination."
             },
             {
                 "field-name": "USCON_GRP_ADSP",
                 "type": "Char",
                 "start": "79",
                 "end": "82",
-                "field-desc": "Does this user have the ADSP attribute in this\ngroup? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Does this user have the ADSP attribute in this group? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USCON_GRP_SPECIAL",
                 "type": "Char",
                 "start": "84",
                 "end": "87",
-                "field-desc": "Does this user have GROUP-SPECIAL in this group?\nValid Values include \"Yes\" and \"No\"."
+                "field-desc": "Does this user have GROUP-SPECIAL in this group? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USCON_GRP_OPER",
                 "type": "Char",
                 "start": "89",
                 "end": "92",
-                "field-desc": "Does this user have GROUP-OPERATIONS in this group?\nValid Values include \"Yes\" and \"No\"."
+                "field-desc": "Does this user have GROUP-OPERATIONS in this group? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USCON_REVOKE",
                 "type": "Char",
                 "start": "94",
                 "end": "97",
-                "field-desc": "Is this user revoked? Valid Values include \"Yes\"\nand \"No\"."
+                "field-desc": "Is this user revoked? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USCON_GRP_ACC",
                 "type": "Char",
                 "start": "99",
                 "end": "102",
-                "field-desc": "Does this user have the GRPACC attribute? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Does this user have the GRPACC attribute? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USCON_NOTERMUACC",
                 "type": "Char",
                 "start": "104",
                 "end": "107",
-                "field-desc": "Does this user have the NOTERMUACC attribute in\nthis group? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Does this user have the NOTERMUACC attribute in this group? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USCON_GRP_AUDIT",
                 "type": "Char",
                 "start": "109",
                 "end": "112",
-                "field-desc": "Does this user have the GROUP-AUDITOR attribute\nin this group? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Does this user have the GROUP-AUDITOR attribute in this group? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USCON_REVOKE_DATE",
                 "type": "Date",
                 "start": "114",
                 "end": "123",
-                "field-desc": "The date that the user's connection to the group\nis revoked."
+                "field-desc": "The date that the user's connection to the group is revoked."
             },
             {
                 "field-name": "USCON_RESUME_DATE",
                 "type": "Date",
                 "start": "125",
                 "end": "134",
-                "field-desc": "The date that the user's connection to the group\nis resumed."
+                "field-desc": "The date that the user's connection to the group is resumed."
             }
         ]
     },
-    "User RRSF data record ": {
+    "user-rrsf-data-record": {
         "record-type": "0206",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -1015,49 +1015,49 @@
                 "type": "Char",
                 "start": "37",
                 "end": "40",
-                "field-desc": "Is this a peer user ID? Valid Values include \"Yes\"\nand \"No\"."
+                "field-desc": "Is this a peer user ID? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USRSF_MANAGING",
                 "type": "Char",
                 "start": "42",
                 "end": "45",
-                "field-desc": "Is USRSF_NAME managing this ID? Valid Values include\n\"Yes\" and \"No\"."
+                "field-desc": "Is USRSF_NAME managing this ID? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USRSF_MANAGED",
                 "type": "Char",
                 "start": "47",
                 "end": "50",
-                "field-desc": "Is USRSF_NAME being managed by this ID? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is USRSF_NAME being managed by this ID? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USRSF_REMOTE_PEND",
                 "type": "Char",
                 "start": "52",
                 "end": "55",
-                "field-desc": "Is this remote RACF association\npending? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Is this remote RACF association pending? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USRSF_LOCAL_PEND",
                 "type": "Char",
                 "start": "57",
                 "end": "60",
-                "field-desc": "Is this local RACF association\npending? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Is this local RACF association pending? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USRSF_PWD_SYNC",
                 "type": "Char",
                 "start": "62",
                 "end": "65",
-                "field-desc": "Is there password synchronization with this user\nID? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Is there password synchronization with this user ID? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USRSF_REM_REFUSAL",
                 "type": "Char",
                 "start": "67",
                 "end": "70",
-                "field-desc": "Was a system error encountered on the remote system?\nValid Values include \"Yes\" and \"No\"."
+                "field-desc": "Was a system error encountered on the remote system? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USRSF_DEFINE_DATE",
@@ -1078,14 +1078,14 @@
                 "type": "Date",
                 "start": "99",
                 "end": "108",
-                "field-desc": "GMT date stamp when this association was approved\nor refused. Based on the REMOTE_REFUSAL bit setting."
+                "field-desc": "GMT date stamp when this association was approved or refused. Based on the REMOTE_REFUSAL bit setting."
             },
             {
                 "field-name": "USRSF_ACCEPT_TIME",
                 "type": "Time",
                 "start": "110",
                 "end": "124",
-                "field-desc": "GMT time stamp when this association was approved\nor refused. Based on the REMOTE_REFUSAL bit setting."
+                "field-desc": "GMT time stamp when this association was approved or refused. Based on the REMOTE_REFUSAL bit setting."
             },
             {
                 "field-name": "USRSF_CREATOR_ID",
@@ -1096,7 +1096,7 @@
             }
         ]
     },
-    "User certificate name record ": {
+    "user-certificate-name-record": {
         "record-type": "0207",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -1105,7 +1105,7 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the user certificate name record\n(0207)."
+                "field-desc": "Record type of the user certificate name record (0207)."
             },
             {
                 "field-name": "USCERT_NAME",
@@ -1130,7 +1130,7 @@
             }
         ]
     },
-    "User associated mappings record ": {
+    "user-associated-mappings-record": {
         "record-type": "0208",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -1139,7 +1139,7 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the User Associated Mappings record\n(0208)."
+                "field-desc": "Record type of the User Associated Mappings record (0208)."
             },
             {
                 "field-name": "USNMAP_NAME",
@@ -1160,11 +1160,11 @@
                 "type": "Char",
                 "start": "48",
                 "end": "293",
-                "field-desc": "The name of the DIGTNMAP profile associated with\nthis user."
+                "field-desc": "The name of the DIGTNMAP profile associated with this user."
             }
         ]
     },
-    "User associated distributed mappings record ": {
+    "user-associated-distributed-mappings-record": {
         "record-type": "0209",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -1173,7 +1173,7 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the User Associated Distributed\nMappings record (0209)."
+                "field-desc": "Record type of the User Associated Distributed Mappings record (0209)."
             },
             {
                 "field-name": "USDMAP_NAME",
@@ -1194,11 +1194,11 @@
                 "type": "Char",
                 "start": "48",
                 "end": "293",
-                "field-desc": null
+                "field-desc": "The name of the IDIDMAP profile associated with this user."
             }
         ]
     },
-    "User MFA factor data record ": {
+    "user-mfa-factor-data-record": {
         "record-type": "020A",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -1232,7 +1232,7 @@
             }
         ]
     },
-    "User MFA policies record ": {
+    "user-mfa-policies-record": {
         "record-type": "020B",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -1241,7 +1241,7 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the user Multi-factor authentication policies record\n(020B)"
+                "field-desc": "Record type of the user Multi-factor authentication policies record (020B)"
             },
             {
                 "field-name": "USMPOL_NAME",
@@ -1259,7 +1259,7 @@
             }
         ]
     },
-    "User DFP data record ": {
+    "user-dfp-data-record": {
         "record-type": "0210",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -1307,7 +1307,7 @@
             }
         ]
     },
-    "User TSO data record ": {
+    "user-tso-data-record": {
         "record-type": "0220",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -1407,7 +1407,7 @@
                 "type": "Char",
                 "start": "196",
                 "end": "203",
-                "field-desc": null
+                "field-desc": "The TSO user data, in hexadecimal in the form "
             },
             {
                 "field-name": "USTSO_UNIT_NAME",
@@ -1425,7 +1425,7 @@
             }
         ]
     },
-    "User CICS data record ": {
+    "user-cics-data-record": {
         "record-type": "0230",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -1448,32 +1448,32 @@
                 "type": "Char",
                 "start": "15",
                 "end": "17",
-                "field-desc": "The CICS operator\nidentifier."
+                "field-desc": "The CICS operator identifier."
             },
             {
                 "field-name": "USCICS_OPPRTY",
                 "type": "Int",
                 "start": "19",
                 "end": "23",
-                "field-desc": "The CICS operator\npriority."
+                "field-desc": "The CICS operator priority."
             },
             {
                 "field-name": "USCICS_NOFORCE",
                 "type": "Char",
                 "start": "25",
                 "end": "28",
-                "field-desc": "Is the extended recovery facility (XRF) NOFORCE\noption in effect? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Is the extended recovery facility (XRF) NOFORCE option in effect? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USCICS_TIMEOUT",
                 "type": "Char",
                 "start": "30",
                 "end": "34",
-                "field-desc": null
+                "field-desc": "The terminal time-out value. Expressed in "
             }
         ]
     },
-    "User CICS operator classes record ": {
+    "user-cics-operator-classes-record": {
         "record-type": "0231",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -1500,7 +1500,7 @@
             }
         ]
     },
-    "User CICS RSL keys record ": {
+    "user-cics-rsl-keys-record": {
         "record-type": "0232",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -1527,7 +1527,7 @@
             }
         ]
     },
-    "User CICS TSL keys record ": {
+    "user-cics-tsl-keys-record": {
         "record-type": "0233",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -1554,7 +1554,7 @@
             }
         ]
     },
-    "User language data record ": {
+    "user-language-data-record": {
         "record-type": "0240",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -1588,7 +1588,7 @@
             }
         ]
     },
-    "User OPERPARM data record ": {
+    "user-operparm-data-record": {
         "record-type": "0250",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -1611,1106 +1611,1106 @@
                 "type": "Int",
                 "start": "15",
                 "end": "19",
-                "field-desc": "The number of megabytes of storage that can be\nused for message queuing."
+                "field-desc": "The number of megabytes of storage that can be used for message queuing."
             },
             {
                 "field-name": "USOPR_MASTERAUTH",
                 "type": "Char",
                 "start": "21",
                 "end": "24",
-                "field-desc": "Does this user have MASTER console authority?\nValid Values include \"Yes\" and \"No\"."
+                "field-desc": "Does this user have MASTER console authority? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ALLAUTH",
                 "type": "Char",
                 "start": "26",
                 "end": "29",
-                "field-desc": "Does this user have ALL console authority? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Does this user have ALL console authority? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_SYSAUTH",
                 "type": "Char",
                 "start": "31",
                 "end": "34",
-                "field-desc": "Does this user have SYSAUTH console authority?\nValid Values include \"Yes\" and \"No\"."
+                "field-desc": "Does this user have SYSAUTH console authority? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_IOAUTH",
                 "type": "Char",
                 "start": "36",
                 "end": "39",
-                "field-desc": "Does this user have I/O console authority? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Does this user have I/O console authority? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_CONSAUTH",
                 "type": "Char",
                 "start": "41",
                 "end": "44",
-                "field-desc": "Does this user have CONS console authority? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Does this user have CONS console authority? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_INFOAUTH",
                 "type": "Char",
                 "start": "46",
                 "end": "49",
-                "field-desc": "Does this user have INFO console authority? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Does this user have INFO console authority? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_TIMESTAMP",
                 "type": "Char",
                 "start": "51",
                 "end": "54",
-                "field-desc": "Do console messages contain a timestamp? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Do console messages contain a timestamp? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_SYSTEMID",
                 "type": "Char",
                 "start": "56",
                 "end": "59",
-                "field-desc": "Do console messages contain a system ID? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Do console messages contain a system ID? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_JOBID",
                 "type": "Char",
                 "start": "61",
                 "end": "64",
-                "field-desc": "Do console messages contain a job ID? Valid Values\ninclude \"Yes\" and \"No\"."
+                "field-desc": "Do console messages contain a job ID? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_MSGID",
                 "type": "Char",
                 "start": "66",
                 "end": "69",
-                "field-desc": "Do console messages contain a message ID? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Do console messages contain a message ID? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_X",
                 "type": "Char",
                 "start": "71",
                 "end": "74",
-                "field-desc": "Are the job name and system name to be suppressed\nfor messages issued from the JES3 global processor? Valid Values include\n\"Yes\" and \"No\"."
+                "field-desc": "Are the job name and system name to be suppressed for messages issued from the JES3 global processor? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_WTOR",
                 "type": "Char",
                 "start": "76",
                 "end": "79",
-                "field-desc": "Does the console receive WTOR messages? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Does the console receive WTOR messages? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_IMMEDIATE",
                 "type": "Char",
                 "start": "81",
                 "end": "84",
-                "field-desc": null
+                "field-desc": "Does the console receive "
             },
             {
                 "field-name": "USOPR_CRITICAL",
                 "type": "Char",
                 "start": "86",
                 "end": "89",
-                "field-desc": null
+                "field-desc": "Does the console receive "
             },
             {
                 "field-name": "USOPR_EVENTUAL",
                 "type": "Char",
                 "start": "91",
                 "end": "94",
-                "field-desc": null
+                "field-desc": "Does the console receive "
             },
             {
                 "field-name": "USOPR_INFO",
                 "type": "Char",
                 "start": "96",
                 "end": "99",
-                "field-desc": null
+                "field-desc": "Does the console receive "
             },
             {
                 "field-name": "USOPR_NOBRODCAST",
                 "type": "Char",
                 "start": "101",
                 "end": "104",
-                "field-desc": "Are broadcast messages to this console suppressed?\nValid Values include \"Yes\" and \"No\"."
+                "field-desc": "Are broadcast messages to this console suppressed? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ALL",
                 "type": "Char",
                 "start": "106",
                 "end": "109",
-                "field-desc": null
+                "field-desc": "Does the console receive "
             },
             {
                 "field-name": "USOPR_JOBNAMES",
                 "type": "Char",
                 "start": "111",
                 "end": "114",
-                "field-desc": "Are job names monitored? Valid Values include\n\"Yes\" and \"No\"."
+                "field-desc": "Are job names monitored? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_JOBNAMEST",
                 "type": "Char",
                 "start": "116",
                 "end": "119",
-                "field-desc": "Are job names monitored with timestamps displayed?\nValid Values include \"Yes\" and \"No\"."
+                "field-desc": "Are job names monitored with timestamps displayed? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_SESS",
                 "type": "Char",
                 "start": "121",
                 "end": "124",
-                "field-desc": "Are user IDs displayed with each TSO initiation\nand termination? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Are user IDs displayed with each TSO initiation and termination? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_SESST",
                 "type": "Char",
                 "start": "126",
                 "end": "129",
-                "field-desc": "Are user IDs and timestamps displayed with each\nTSO initiation and termination? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Are user IDs and timestamps displayed with each TSO initiation and termination? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_STATUS",
                 "type": "Char",
                 "start": "131",
                 "end": "134",
-                "field-desc": "Are data set names and dispositions displayed\nwith each data set that is freed? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Are data set names and dispositions displayed with each data set that is freed? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE001",
                 "type": "Char",
                 "start": "136",
                 "end": "139",
-                "field-desc": "Is this console enabled for route code 001? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 001? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE002",
                 "type": "Char",
                 "start": "141",
                 "end": "144",
-                "field-desc": "Is this console enabled for route code 002? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 002? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE003",
                 "type": "Char",
                 "start": "146",
                 "end": "149",
-                "field-desc": "Is this console enabled for route code 003? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 003? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE004",
                 "type": "Char",
                 "start": "151",
                 "end": "154",
-                "field-desc": "Is this console enabled for route code 004? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 004? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE005",
                 "type": "Char",
                 "start": "156",
                 "end": "159",
-                "field-desc": "Is this console enabled for route code 005? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 005? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE006",
                 "type": "Char",
                 "start": "161",
                 "end": "164",
-                "field-desc": "Is this console enabled for route code 006? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 006? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE007",
                 "type": "Char",
                 "start": "166",
                 "end": "169",
-                "field-desc": "Is this console enabled for route code 007? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 007? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE008",
                 "type": "Char",
                 "start": "171",
                 "end": "174",
-                "field-desc": "Is this console enabled for route code 008? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 008? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE009",
                 "type": "Char",
                 "start": "176",
                 "end": "179",
-                "field-desc": "Is this console enabled for route code 009? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 009? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE010",
                 "type": "Char",
                 "start": "181",
                 "end": "184",
-                "field-desc": "Is this console enabled for route code 010? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 010? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE011",
                 "type": "Char",
                 "start": "186",
                 "end": "189",
-                "field-desc": "Is this console enabled for route code 011? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 011? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE012",
                 "type": "Char",
                 "start": "191",
                 "end": "194",
-                "field-desc": "Is this console enabled for route code 012? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 012? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE013",
                 "type": "Char",
                 "start": "196",
                 "end": "199",
-                "field-desc": "Is this console enabled for route code 013? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 013? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE014",
                 "type": "Char",
                 "start": "201",
                 "end": "204",
-                "field-desc": "Is this console enabled for route code 014? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 014? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE015",
                 "type": "Char",
                 "start": "206",
                 "end": "209",
-                "field-desc": "Is this console enabled for route code 015? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 015? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE016",
                 "type": "Char",
                 "start": "211",
                 "end": "214",
-                "field-desc": "Is this console enabled for route code 016? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 016? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE017",
                 "type": "Char",
                 "start": "216",
                 "end": "219",
-                "field-desc": "Is this console enabled for route code 017? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 017? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE018",
                 "type": "Char",
                 "start": "221",
                 "end": "224",
-                "field-desc": "Is this console enabled for route code 018? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 018? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE019",
                 "type": "Char",
                 "start": "226",
                 "end": "229",
-                "field-desc": "Is this console enabled for route code 019? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 019? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE020",
                 "type": "Char",
                 "start": "231",
                 "end": "234",
-                "field-desc": "Is this console enabled for route code 020? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 020? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE021",
                 "type": "Char",
                 "start": "236",
                 "end": "239",
-                "field-desc": "Is this console enabled for route code 021? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 021? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE022",
                 "type": "Char",
                 "start": "241",
                 "end": "244",
-                "field-desc": "Is this console enabled for route code 022? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 022? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE023",
                 "type": "Char",
                 "start": "246",
                 "end": "249",
-                "field-desc": "Is this console enabled for route code 023? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 023? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE024",
                 "type": "Char",
                 "start": "251",
                 "end": "254",
-                "field-desc": "Is this console enabled for route code 024? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 024? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE025",
                 "type": "Char",
                 "start": "256",
                 "end": "259",
-                "field-desc": "Is this console enabled for route code 025? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 025? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE026",
                 "type": "Char",
                 "start": "261",
                 "end": "264",
-                "field-desc": "Is this console enabled for route code 026? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 026? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE027",
                 "type": "Char",
                 "start": "266",
                 "end": "269",
-                "field-desc": "Is this console enabled for route code 027? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 027? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE028",
                 "type": "Char",
                 "start": "271",
                 "end": "274",
-                "field-desc": "Is this console enabled for route code 028? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 028? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE029",
                 "type": "Char",
                 "start": "276",
                 "end": "279",
-                "field-desc": "Is this console enabled for route code 029? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 029? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE030",
                 "type": "Char",
                 "start": "281",
                 "end": "284",
-                "field-desc": "Is this console enabled for route code 030? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 030? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE031",
                 "type": "Char",
                 "start": "286",
                 "end": "289",
-                "field-desc": "Is this console enabled for route code 031? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 031? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE032",
                 "type": "Char",
                 "start": "291",
                 "end": "294",
-                "field-desc": "Is this console enabled for route code 032? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 032? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE033",
                 "type": "Char",
                 "start": "296",
                 "end": "299",
-                "field-desc": "Is this console enabled for route code 033? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 033? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE034",
                 "type": "Char",
                 "start": "301",
                 "end": "304",
-                "field-desc": "Is this console enabled for route code 034? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 034? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE035",
                 "type": "Char",
                 "start": "306",
                 "end": "309",
-                "field-desc": "Is this console enabled for route code 035? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 035? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE036",
                 "type": "Char",
                 "start": "311",
                 "end": "314",
-                "field-desc": "Is this console enabled for route code 036? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 036? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE037",
                 "type": "Char",
                 "start": "316",
                 "end": "319",
-                "field-desc": "Is this console enabled for route code 037? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 037? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE038",
                 "type": "Char",
                 "start": "321",
                 "end": "324",
-                "field-desc": "Is this console enabled for route code 038? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 038? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE039",
                 "type": "Char",
                 "start": "326",
                 "end": "329",
-                "field-desc": "Is this console enabled for route code 039? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 039? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE040",
                 "type": "Char",
                 "start": "331",
                 "end": "334",
-                "field-desc": "Is this console enabled for route code 040? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 040? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE041",
                 "type": "Char",
                 "start": "336",
                 "end": "339",
-                "field-desc": "Is this console enabled for route code 041? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 041? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE042",
                 "type": "Char",
                 "start": "341",
                 "end": "344",
-                "field-desc": "Is this console enabled for route code 042? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 042? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE043",
                 "type": "Char",
                 "start": "346",
                 "end": "349",
-                "field-desc": "Is this console enabled for route code 043? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 043? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE044",
                 "type": "Char",
                 "start": "351",
                 "end": "354",
-                "field-desc": "Is this console enabled for route code 044? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 044? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE045",
                 "type": "Char",
                 "start": "356",
                 "end": "359",
-                "field-desc": "Is this console enabled for route code 045? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 045? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE046",
                 "type": "Char",
                 "start": "361",
                 "end": "364",
-                "field-desc": "Is this console enabled for route code 046? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 046? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE047",
                 "type": "Char",
                 "start": "366",
                 "end": "369",
-                "field-desc": "Is this console enabled for route code 047? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 047? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE048",
                 "type": "Char",
                 "start": "371",
                 "end": "374",
-                "field-desc": "Is this console enabled for route code 048? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 048? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE049",
                 "type": "Char",
                 "start": "376",
                 "end": "379",
-                "field-desc": "Is this console enabled for route code 049? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 049? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE050",
                 "type": "Char",
                 "start": "381",
                 "end": "384",
-                "field-desc": "Is this console enabled for route code 050? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 050? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE051",
                 "type": "Char",
                 "start": "386",
                 "end": "389",
-                "field-desc": "Is this console enabled for route code 051? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 051? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE052",
                 "type": "Char",
                 "start": "391",
                 "end": "394",
-                "field-desc": "Is this console enabled for route code 052? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 052? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE053",
                 "type": "Char",
                 "start": "396",
                 "end": "399",
-                "field-desc": "Is this console enabled for route code 053? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 053? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE054",
                 "type": "Char",
                 "start": "401",
                 "end": "404",
-                "field-desc": "Is this console enabled for route code 054? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 054? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE055",
                 "type": "Char",
                 "start": "406",
                 "end": "409",
-                "field-desc": "Is this console enabled for route code 055? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 055? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE056",
                 "type": "Char",
                 "start": "411",
                 "end": "414",
-                "field-desc": "Is this console enabled for route code 056? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 056? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE057",
                 "type": "Char",
                 "start": "416",
                 "end": "419",
-                "field-desc": "Is this console enabled for route code 057? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 057? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE058",
                 "type": "Char",
                 "start": "421",
                 "end": "424",
-                "field-desc": "Is this console enabled for route code 058? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 058? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE059",
                 "type": "Char",
                 "start": "426",
                 "end": "429",
-                "field-desc": "Is this console enabled for route code 059? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 059? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE060",
                 "type": "Char",
                 "start": "431",
                 "end": "434",
-                "field-desc": "Is this console enabled for route code 060? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 060? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE061",
                 "type": "Char",
                 "start": "436",
                 "end": "439",
-                "field-desc": "Is this console enabled for route code 061? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 061? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE062",
                 "type": "Char",
                 "start": "441",
                 "end": "444",
-                "field-desc": "Is this console enabled for route code 062? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 062? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE063",
                 "type": "Char",
                 "start": "446",
                 "end": "449",
-                "field-desc": "Is this console enabled for route code 063? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 063? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE064",
                 "type": "Char",
                 "start": "451",
                 "end": "454",
-                "field-desc": "Is this console enabled for route code 064? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 064? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE065",
                 "type": "Char",
                 "start": "456",
                 "end": "459",
-                "field-desc": "Is this console enabled for route code 065? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 065? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE066",
                 "type": "Char",
                 "start": "461",
                 "end": "464",
-                "field-desc": "Is this console enabled for route code 066? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 066? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE067",
                 "type": "Char",
                 "start": "466",
                 "end": "469",
-                "field-desc": "Is this console enabled for route code 067? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 067? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE068",
                 "type": "Char",
                 "start": "471",
                 "end": "474",
-                "field-desc": "Is this console enabled for route code 068? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 068? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE069",
                 "type": "Char",
                 "start": "476",
                 "end": "479",
-                "field-desc": "Is this console enabled for route code 069? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 069? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE070",
                 "type": "Char",
                 "start": "481",
                 "end": "484",
-                "field-desc": "Is this console enabled for route code 070? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 070? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE071",
                 "type": "Char",
                 "start": "486",
                 "end": "489",
-                "field-desc": "Is this console enabled for route code 071? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 071? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE072",
                 "type": "Char",
                 "start": "491",
                 "end": "494",
-                "field-desc": "Is this console enabled for route code 072? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 072? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE073",
                 "type": "Char",
                 "start": "496",
                 "end": "499",
-                "field-desc": "Is this console enabled for route code 073? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 073? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE074",
                 "type": "Char",
                 "start": "501",
                 "end": "504",
-                "field-desc": "Is this console enabled for route code 074? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 074? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE075",
                 "type": "Char",
                 "start": "506",
                 "end": "509",
-                "field-desc": "Is this console enabled for route code 075? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 075? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE076",
                 "type": "Char",
                 "start": "511",
                 "end": "514",
-                "field-desc": "Is this console enabled for route code 076? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 076? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE077",
                 "type": "Char",
                 "start": "516",
                 "end": "519",
-                "field-desc": "Is this console enabled for route code 077? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 077? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE078",
                 "type": "Char",
                 "start": "521",
                 "end": "524",
-                "field-desc": "Is this console enabled for route code 078? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 078? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE079",
                 "type": "Char",
                 "start": "526",
                 "end": "529",
-                "field-desc": "Is this console enabled for route code 079? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 079? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE080",
                 "type": "Char",
                 "start": "531",
                 "end": "534",
-                "field-desc": "Is this console enabled for route code 080? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 080? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE081",
                 "type": "Char",
                 "start": "536",
                 "end": "539",
-                "field-desc": "Is this console enabled for route code 081? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 081? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE082",
                 "type": "Char",
                 "start": "541",
                 "end": "544",
-                "field-desc": "Is this console enabled for route code 082? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 082? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE083",
                 "type": "Char",
                 "start": "546",
                 "end": "549",
-                "field-desc": "Is this console enabled for route code 083? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 083? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE084",
                 "type": "Char",
                 "start": "551",
                 "end": "554",
-                "field-desc": "Is this console enabled for route code 084? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 084? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE085",
                 "type": "Char",
                 "start": "556",
                 "end": "559",
-                "field-desc": "Is this console enabled for route code 085? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 085? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE086",
                 "type": "Char",
                 "start": "561",
                 "end": "564",
-                "field-desc": "Is this console enabled for route code 086? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 086? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE087",
                 "type": "Char",
                 "start": "566",
                 "end": "569",
-                "field-desc": "Is this console enabled for route code 087? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 087? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE088",
                 "type": "Char",
                 "start": "571",
                 "end": "574",
-                "field-desc": "Is this console enabled for route code 088? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 088? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE089",
                 "type": "Char",
                 "start": "576",
                 "end": "579",
-                "field-desc": "Is this console enabled for route code 089? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 089? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE090",
                 "type": "Char",
                 "start": "581",
                 "end": "584",
-                "field-desc": "Is this console enabled for route code 090? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 090? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE091",
                 "type": "Char",
                 "start": "586",
                 "end": "589",
-                "field-desc": "Is this console enabled for route code 091? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 091? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE092",
                 "type": "Char",
                 "start": "591",
                 "end": "594",
-                "field-desc": "Is this console enabled for route code 092? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 092? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE093",
                 "type": "Char",
                 "start": "596",
                 "end": "599",
-                "field-desc": "Is this console enabled for route code 093? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 093? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE094",
                 "type": "Char",
                 "start": "601",
                 "end": "604",
-                "field-desc": "Is this console enabled for route code 094? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 094? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE095",
                 "type": "Char",
                 "start": "606",
                 "end": "609",
-                "field-desc": "Is this console enabled for route code 095? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 095? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE096",
                 "type": "Char",
                 "start": "611",
                 "end": "614",
-                "field-desc": "Is this console enabled for route code 096? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 096? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE097",
                 "type": "Char",
                 "start": "616",
                 "end": "619",
-                "field-desc": "Is this console enabled for route code 097? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 097? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE098",
                 "type": "Char",
                 "start": "621",
                 "end": "624",
-                "field-desc": "Is this console enabled for route code 098? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 098? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE099",
                 "type": "Char",
                 "start": "626",
                 "end": "629",
-                "field-desc": "Is this console enabled for route code 099? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 099? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE100",
                 "type": "Char",
                 "start": "631",
                 "end": "634",
-                "field-desc": "Is this console enabled for route code 100? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 100? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE101",
                 "type": "Char",
                 "start": "636",
                 "end": "639",
-                "field-desc": "Is this console enabled for route code 101? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 101? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE102",
                 "type": "Char",
                 "start": "641",
                 "end": "644",
-                "field-desc": "Is this console enabled for route code 102? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 102? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE103",
                 "type": "Char",
                 "start": "646",
                 "end": "649",
-                "field-desc": "Is this console enabled for route code 103? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 103? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE104",
                 "type": "Char",
                 "start": "651",
                 "end": "654",
-                "field-desc": "Is this console enabled for route code 104? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 104? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE105",
                 "type": "Char",
                 "start": "656",
                 "end": "659",
-                "field-desc": "Is this console enabled for route code 105? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 105? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE106",
                 "type": "Char",
                 "start": "661",
                 "end": "664",
-                "field-desc": "Is this console enabled for route code 106? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 106? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE107",
                 "type": "Char",
                 "start": "666",
                 "end": "669",
-                "field-desc": "Is this console enabled for route code 107? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 107? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE108",
                 "type": "Char",
                 "start": "671",
                 "end": "674",
-                "field-desc": "Is this console enabled for route code 108? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 108? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE109",
                 "type": "Char",
                 "start": "676",
                 "end": "679",
-                "field-desc": "Is this console enabled for route code 109? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 109? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE110",
                 "type": "Char",
                 "start": "681",
                 "end": "684",
-                "field-desc": "Is this console enabled for route code 110? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 110? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE111",
                 "type": "Char",
                 "start": "686",
                 "end": "689",
-                "field-desc": "Is this console enabled for route code 111? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 111? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE112",
                 "type": "Char",
                 "start": "691",
                 "end": "694",
-                "field-desc": "Is this console enabled for route code 112? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 112? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE113",
                 "type": "Char",
                 "start": "696",
                 "end": "699",
-                "field-desc": "Is this console enabled for route code 113? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 113? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE114",
                 "type": "Char",
                 "start": "701",
                 "end": "704",
-                "field-desc": "Is this console enabled for route code 114? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 114? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE115",
                 "type": "Char",
                 "start": "706",
                 "end": "709",
-                "field-desc": "Is this console enabled for route code 115? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 115? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE116",
                 "type": "Char",
                 "start": "711",
                 "end": "714",
-                "field-desc": "Is this console enabled for route code 116? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 116? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE117",
                 "type": "Char",
                 "start": "716",
                 "end": "719",
-                "field-desc": "Is this console enabled for route code 117? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 117? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE118",
                 "type": "Char",
                 "start": "721",
                 "end": "724",
-                "field-desc": "Is this console enabled for route code 118? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 118? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE119",
                 "type": "Char",
                 "start": "726",
                 "end": "729",
-                "field-desc": "Is this console enabled for route code 119? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 119? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE120",
                 "type": "Char",
                 "start": "731",
                 "end": "734",
-                "field-desc": "Is this console enabled for route code 120? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 120? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE121",
                 "type": "Char",
                 "start": "736",
                 "end": "739",
-                "field-desc": "Is this console enabled for route code 121? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 121? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE122",
                 "type": "Char",
                 "start": "741",
                 "end": "744",
-                "field-desc": "Is this console enabled for route code 122? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 122? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE123",
                 "type": "Char",
                 "start": "746",
                 "end": "749",
-                "field-desc": "Is this console enabled for route code 123? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 123? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE124",
                 "type": "Char",
                 "start": "751",
                 "end": "754",
-                "field-desc": "Is this console enabled for route code 124? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 124? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE125",
                 "type": "Char",
                 "start": "756",
                 "end": "759",
-                "field-desc": "Is this console enabled for route code 125? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 125? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE126",
                 "type": "Char",
                 "start": "761",
                 "end": "764",
-                "field-desc": "Is this console enabled for route code 126? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 126? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE127",
                 "type": "Char",
                 "start": "766",
                 "end": "769",
-                "field-desc": "Is this console enabled for route code 127? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 127? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ROUTECODE128",
                 "type": "Char",
                 "start": "771",
                 "end": "774",
-                "field-desc": "Is this console enabled for route code 128? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is this console enabled for route code 128? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_LOGCMDRESP",
                 "type": "Char",
                 "start": "776",
                 "end": "783",
-                "field-desc": null
+                "field-desc": "Specifies the logging of command responses received by the extended operator. Valid values are "
             },
             {
                 "field-name": "USOPR_MIGRATIONID",
                 "type": "Char",
                 "start": "785",
                 "end": "788",
-                "field-desc": "Is this extended operator to receive a migration\nID?"
+                "field-desc": "Is this extended operator to receive a migration ID?"
             },
             {
                 "field-name": "USOPR_DELOPERMSG",
                 "type": "Char",
                 "start": "790",
                 "end": "797",
-                "field-desc": null
+                "field-desc": "Does this extended operator receive delete operator messages? Valid values are "
             },
             {
                 "field-name": "USOPR_RETRIEVE_KEY",
                 "type": "Char",
                 "start": "799",
                 "end": "806",
-                "field-desc": null
+                "field-desc": "Specifies a retrieval key used for searching. A null value is indicated by "
             },
             {
                 "field-name": "USOPR_CMDSYS",
                 "type": "Char",
                 "start": "808",
                 "end": "815",
-                "field-desc": "The name of the system that the extended operator\nis connected to for command processing."
+                "field-desc": "The name of the system that the extended operator is connected to for command processing."
             },
             {
                 "field-name": "USOPR_UD",
                 "type": "Char",
                 "start": "817",
                 "end": "820",
-                "field-desc": "Is this operator to receive undeliverable messages?\nValid Values include \"Yes\" and \"No\"."
+                "field-desc": "Is this operator to receive undeliverable messages? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_ALTGRP_ID",
@@ -2724,32 +2724,32 @@
                 "type": "Char",
                 "start": "831",
                 "end": "834",
-                "field-desc": "Is this operator to receive messages automated\nwithin the sysplex? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Is this operator to receive messages automated within the sysplex? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_HC",
                 "type": "Char",
                 "start": "836",
                 "end": "839",
-                "field-desc": "Is this operator to receive messages that are\ndirected to hardcopy? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Is this operator to receive messages that are directed to hardcopy? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_INT",
                 "type": "Char",
                 "start": "841",
                 "end": "844",
-                "field-desc": "Is this operator to receive messages that are\ndirected to console ID zero? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Is this operator to receive messages that are directed to console ID zero? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USOPR_UNKN",
                 "type": "Char",
                 "start": "846",
                 "end": "849",
-                "field-desc": "Is this operator to receive messages which are\ndirected to unknown console IDs? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Is this operator to receive messages which are directed to unknown console IDs? Valid Values include \"Yes\" and \"No\"."
             }
         ]
     },
-    "User OPERPARM scope ": {
+    "user-operparm-scope": {
         "record-type": "0251",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -2758,7 +2758,7 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the User OPERPARM Scope record\n(0251)."
+                "field-desc": "Record type of the User OPERPARM Scope record (0251)."
             },
             {
                 "field-name": "USOPRP_NAME",
@@ -2776,7 +2776,7 @@
             }
         ]
     },
-    "User WORKATTR data record ": {
+    "user-workattr-data-record": {
         "record-type": "0260",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -2866,7 +2866,7 @@
             }
         ]
     },
-    "User OMVS data record ": {
+    "user-omvs-data-record": {
         "record-type": "0270",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -2889,21 +2889,21 @@
                 "type": "Char",
                 "start": "15",
                 "end": "24",
-                "field-desc": null
+                "field-desc": "z/OS UNIX"
             },
             {
                 "field-name": "USOMVS_HOME_PATH",
                 "type": "Char",
                 "start": "26",
                 "end": "1048",
-                "field-desc": null
+                "field-desc": "HOME PATH associated with the "
             },
             {
                 "field-name": "USOMVS_PROGRAM",
                 "type": "Char",
                 "start": "1050",
                 "end": "2072",
-                "field-desc": null
+                "field-desc": "Default Program associated with the "
             },
             {
                 "field-name": "USOMVS_CPUTIMEMAX",
@@ -2917,35 +2917,35 @@
                 "type": "Int",
                 "start": "2085",
                 "end": "2094",
-                "field-desc": "Maximum address space size associated with the\nUID."
+                "field-desc": "Maximum address space size associated with the UID."
             },
             {
                 "field-name": "USOMVS_FILEPROCMAX",
                 "type": "Int",
                 "start": "2096",
                 "end": "2105",
-                "field-desc": "Maximum active or open files associated with the\nUID."
+                "field-desc": "Maximum active or open files associated with the UID."
             },
             {
                 "field-name": "USOMVS_PROCUSERMAX",
                 "type": "Int",
                 "start": "2107",
                 "end": "2116",
-                "field-desc": "Maximum number of processes associated with the\nUID."
+                "field-desc": "Maximum number of processes associated with the UID."
             },
             {
                 "field-name": "USOMVS_THREADSMAX",
                 "type": "Int",
                 "start": "2118",
                 "end": "2127",
-                "field-desc": "Maximum number of threads associated with the\nUID."
+                "field-desc": "Maximum number of threads associated with the UID."
             },
             {
                 "field-name": "USOMVS_MMAPAREAMAX",
                 "type": "Int",
                 "start": "2129",
                 "end": "2138",
-                "field-desc": "Maximum mappable storage amount associated with\nthe UID."
+                "field-desc": "Maximum mappable storage amount associated with the UID."
             },
             {
                 "field-name": "USOMVS_MEMLIMIT",
@@ -2963,7 +2963,7 @@
             }
         ]
     },
-    "User NETVIEW segment record ": {
+    "user-netview-segment-record": {
         "record-type": "0280",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -2972,7 +2972,7 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the user NETVIEW segment record\n(0280)."
+                "field-desc": "Record type of the user NETVIEW segment record (0280)."
             },
             {
                 "field-name": "USNETV_NAME",
@@ -3007,14 +3007,14 @@
                 "type": "Char",
                 "start": "289",
                 "end": "292",
-                "field-desc": "Eligible to receive unsolicited messages? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Eligible to receive unsolicited messages? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USNETV_NGMFADMN",
                 "type": "Char",
                 "start": "294",
                 "end": "297",
-                "field-desc": "Authorized to NetView graphic\nmonitoring facility? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Authorized to NetView graphic monitoring facility? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USNETV_NGMFVSPN",
@@ -3025,7 +3025,7 @@
             }
         ]
     },
-    "User OPCLASS record ": {
+    "user-opclass-record": {
         "record-type": "0281",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -3052,7 +3052,7 @@
             }
         ]
     },
-    "User DOMAINS record ": {
+    "user-domains-record": {
         "record-type": "0282",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -3079,7 +3079,7 @@
             }
         ]
     },
-    "User DCE data record ": {
+    "user-dce-data-record": {
         "record-type": "0290",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -3095,14 +3095,14 @@
                 "type": "Char",
                 "start": "6",
                 "end": "13",
-                "field-desc": "RACF user\nname as taken from the profile name."
+                "field-desc": "RACF user name as taken from the profile name."
             },
             {
                 "field-name": "USDCE_UUID",
                 "type": "Char",
                 "start": "15",
                 "end": "50",
-                "field-desc": "DCE UUID associated with the user name from the\nprofile."
+                "field-desc": "DCE UUID associated with the user name from the profile."
             },
             {
                 "field-name": "USDCE_DCE_NAME",
@@ -3130,11 +3130,11 @@
                 "type": "Char",
                 "start": "2137",
                 "end": "2140",
-                "field-desc": "Is this user eligible for an automatic DCE login?\nValid Values include \"Yes\" and \"No\"."
+                "field-desc": "Is this user eligible for an automatic DCE login? Valid Values include \"Yes\" and \"No\"."
             }
         ]
     },
-    "User OVM data record ": {
+    "user-ovm-data-record": {
         "record-type": "02A0",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -3157,21 +3157,21 @@
                 "type": "Char",
                 "start": "15",
                 "end": "24",
-                "field-desc": "User identifier (UID) associated with the user\nname from the profile."
+                "field-desc": "User identifier (UID) associated with the user name from the profile."
             },
             {
                 "field-name": "USOVM_HOME_PATH",
                 "type": "Char",
                 "start": "26",
                 "end": "1048",
-                "field-desc": "Home path associated with the user identifier\n(UID)."
+                "field-desc": "Home path associated with the user identifier (UID)."
             },
             {
                 "field-name": "USOVM_PROGRAM",
                 "type": "Char",
                 "start": "1050",
                 "end": "2072",
-                "field-desc": "Default program associated with the user identifier\n(UID)."
+                "field-desc": "Default program associated with the user identifier (UID)."
             },
             {
                 "field-name": "USOVM_FSROOT",
@@ -3182,7 +3182,7 @@
             }
         ]
     },
-    "User LNOTES data record ": {
+    "user-lnotes-data-record": {
         "record-type": "02B0",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -3209,7 +3209,7 @@
             }
         ]
     },
-    "User NDS data record ": {
+    "user-nds-data-record": {
         "record-type": "02C0",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -3236,7 +3236,7 @@
             }
         ]
     },
-    "User KERB data record ": {
+    "user-kerb-data-record": {
         "record-type": "02D0",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -3252,7 +3252,7 @@
                 "type": "Char",
                 "start": "6",
                 "end": "13",
-                "field-desc": "RACF user\nname as taken from the profile."
+                "field-desc": "RACF user name as taken from the profile."
             },
             {
                 "field-name": "USKERB_KERBNAME",
@@ -3273,56 +3273,56 @@
                 "type": "Int",
                 "start": "267",
                 "end": "269",
-                "field-desc": "Current\u00ae key version."
+                "field-desc": "Current  key version."
             },
             {
                 "field-name": "USKERB_ENCRYPT_DES",
                 "type": "Char",
                 "start": "271",
                 "end": "274",
-                "field-desc": "Is key encryption using DES enabled? Valid Values\ninclude \"Yes\" and \"No\"."
+                "field-desc": "Is key encryption using DES enabled? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USKERB_ENCRYPT_DES3",
                 "type": "Char",
                 "start": "276",
                 "end": "279",
-                "field-desc": "Is key encryption using DES3 enabled? Valid Values\ninclude \"Yes\" and \"No\"."
+                "field-desc": "Is key encryption using DES3 enabled? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USKERB_ENCRYPT_DESD",
                 "type": "Char",
                 "start": "281",
                 "end": "284",
-                "field-desc": "Is key encryption using DES with derivation enabled?\nValid Values include \"Yes\" and \"No\"."
+                "field-desc": "Is key encryption using DES with derivation enabled? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USKERB_ENCRPT_A128",
                 "type": "Char",
                 "start": "286",
                 "end": "289",
-                "field-desc": "Is key encryption using AES128 enabled? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is key encryption using AES128 enabled? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USKERB_ENCRPT_A256",
                 "type": "Char",
                 "start": "291",
                 "end": "294",
-                "field-desc": "Is key encryption using AES256 enabled? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is key encryption using AES256 enabled? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USKERB_ENCRPT_A128SHA2",
                 "type": "Char",
                 "start": "296",
                 "end": "299",
-                "field-desc": "Is key encryption using AES128 SHA2 enabled? Valid Values include \"Yes\" and\n\"No\"."
+                "field-desc": "Is key encryption using AES128 SHA2 enabled? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USKERB_ENCRPT_A256SHA2",
                 "type": "Char",
                 "start": "301",
                 "end": "304",
-                "field-desc": "Is key encryption using AES256 SHA2 enabled? Valid Values include \"Yes\" and\n\"No\"."
+                "field-desc": "Is key encryption using AES256 SHA2 enabled? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "USKERB_KEY_FROM",
@@ -3333,7 +3333,7 @@
             }
         ]
     },
-    "User PROXY record ": {
+    "user-proxy-record": {
         "record-type": "02E0",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -3349,7 +3349,7 @@
                 "type": "Char",
                 "start": "6",
                 "end": "13",
-                "field-desc": "RACF user\nname as taken from the profile name."
+                "field-desc": "RACF user name as taken from the profile name."
             },
             {
                 "field-name": "USPROXY_LDAP_HOST",
@@ -3367,7 +3367,7 @@
             }
         ]
     },
-    "User EIM data record ": {
+    "user-eim-data-record": {
         "record-type": "02F0",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -3394,7 +3394,7 @@
             }
         ]
     },
-    "User CSDATA custom fields record ": {
+    "user-csdata-custom-fields-record": {
         "record-type": "02G1",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -3403,7 +3403,7 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the user CSDATA custom fields record\n(02G1)."
+                "field-desc": "Record type of the user CSDATA custom fields record (02G1)."
             },
             {
                 "field-name": "USCSD_NAME",
@@ -3417,7 +3417,7 @@
                 "type": "Char",
                 "start": "15",
                 "end": "18",
-                "field-desc": "Data type for the custom field. Valid values are\nCHAR, FLAG, HEX, NUM."
+                "field-desc": "Data type for the custom field. Valid values are CHAR, FLAG, HEX, NUM."
             },
             {
                 "field-name": "USCSD_KEY",
@@ -3435,7 +3435,7 @@
             }
         ]
     },
-    "User MFA factor tags data record ": {
+    "user-mfa-factor-tags-data-record": {
         "record-type": "1210",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/usr.htm",
         "offsets": [
@@ -3444,7 +3444,7 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the user Multifactor authentication factor configuration data\nrecord (1210)."
+                "field-desc": "Record type of the user Multifactor authentication factor configuration data record (1210)."
             },
             {
                 "field-name": "USMFAC_NAME",
@@ -3476,7 +3476,7 @@
             }
         ]
     },
-    "Data set basic data record ": {
+    "data-set-basic-data-record": {
         "record-type": "0400",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/dsr.htm",
         "offsets": [
@@ -3485,7 +3485,7 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the Data Set Basic Data record\n(0400)."
+                "field-desc": "Record type of the Data Set Basic Data record (0400)."
             },
             {
                 "field-name": "DSBD_NAME",
@@ -3499,11 +3499,11 @@
                 "type": "Char",
                 "start": "51",
                 "end": "56",
-                "field-desc": null
+                "field-desc": "Volume upon which this data set resides. Blank if the profile is generic, and "
             },
             {
                 "field-name": "DSBD_GENERIC",
-                "type": "Yes/No",
+                "type": "YesNo",
                 "start": "58",
                 "end": "61",
                 "field-desc": "Is this a generic profile?"
@@ -3541,39 +3541,39 @@
                 "type": "Int",
                 "start": "105",
                 "end": "109",
-                "field-desc": "The number of times that the data set was accessed\nwith ALTER authority."
+                "field-desc": "The number of times that the data set was accessed with ALTER authority."
             },
             {
                 "field-name": "DSBD_CONTROL_CNT",
                 "type": "Int",
                 "start": "111",
                 "end": "115",
-                "field-desc": "The number of times that the data set was accessed\nwith CONTROL authority."
+                "field-desc": "The number of times that the data set was accessed with CONTROL authority."
             },
             {
                 "field-name": "DSBD_UPDATE_CNT",
                 "type": "Int",
                 "start": "117",
                 "end": "121",
-                "field-desc": "The number of times that the data set was accessed\nwith UPDATE authority."
+                "field-desc": "The number of times that the data set was accessed with UPDATE authority."
             },
             {
                 "field-name": "DSBD_READ_CNT",
                 "type": "Int",
                 "start": "123",
                 "end": "127",
-                "field-desc": "The number of times that the data set was accessed\nwith READ authority."
+                "field-desc": "The number of times that the data set was accessed with READ authority."
             },
             {
                 "field-name": "DSBD_UACC",
                 "type": "Char",
                 "start": "129",
                 "end": "136",
-                "field-desc": null
+                "field-desc": "The universal access of this data set. Valid values are "
             },
             {
                 "field-name": "DSBD_GRPDS",
-                "type": "Yes/No",
+                "type": "YesNo",
                 "start": "138",
                 "end": "141",
                 "field-desc": "Is this a group data set?"
@@ -3583,21 +3583,21 @@
                 "type": "Char",
                 "start": "143",
                 "end": "150",
-                "field-desc": null
+                "field-desc": "Indicates the level of resource-owner-specified auditing that is performed. Valid values are "
             },
             {
                 "field-name": "DSBD_GRP_ID",
                 "type": "Char",
                 "start": "152",
                 "end": "159",
-                "field-desc": "The connect group of the user who created this\ndata set."
+                "field-desc": "The connect group of the user who created this data set."
             },
             {
                 "field-name": "DSBD_DS_TYPE",
                 "type": "Char",
                 "start": "161",
                 "end": "168",
-                "field-desc": null
+                "field-desc": "The type of the data set. Valid values are "
             },
             {
                 "field-name": "DSBD_LEVEL",
@@ -3611,14 +3611,14 @@
                 "type": "Char",
                 "start": "174",
                 "end": "181",
-                "field-desc": "The EBCDIC name of the device type on which the\ndata set resides."
+                "field-desc": "The EBCDIC name of the device type on which the data set resides."
             },
             {
                 "field-name": "DSBD_GAUDIT_LEVEL",
                 "type": "Char",
                 "start": "183",
                 "end": "190",
-                "field-desc": null
+                "field-desc": "Indicates the level of auditor-specified auditing that is performed. Valid values are "
             },
             {
                 "field-name": "DSBD_INSTALL_DATA",
@@ -3632,32 +3632,32 @@
                 "type": "Char",
                 "start": "448",
                 "end": "455",
-                "field-desc": null
+                "field-desc": "The resource-owner-specified successful access audit qualifier. This is set to blanks if "
             },
             {
                 "field-name": "DSBD_AUDIT_FAQUAL",
                 "type": "Char",
                 "start": "457",
                 "end": "464",
-                "field-desc": null
+                "field-desc": "The resource-owner-specified failing access audit qualifier. This is set to blanks if "
             },
             {
                 "field-name": "DSBD_GAUDIT_OKQUAL",
                 "type": "Char",
                 "start": "466",
                 "end": "473",
-                "field-desc": null
+                "field-desc": "The auditor-specified successful access audit qualifier. This is set to blanks if "
             },
             {
                 "field-name": "DSBD_GAUDIT_FAQUAL",
                 "type": "Char",
                 "start": "475",
                 "end": "482",
-                "field-desc": null
+                "field-desc": "The auditor-specified failing access audit qualifier. This is set to blanks if "
             },
             {
                 "field-name": "DSBD_WARNING",
-                "type": "Yes/No",
+                "type": "YesNo",
                 "start": "484",
                 "end": "487",
                 "field-desc": "Does this data set have the WARNING attribute?"
@@ -3685,10 +3685,10 @@
             },
             {
                 "field-name": "DSBD_ERASE",
-                "type": "Yes/No",
+                "type": "YesNo",
                 "start": "508",
                 "end": "511",
-                "field-desc": "For a DASD data set, is this data set scratched\nwhen the data set is deleted?"
+                "field-desc": "For a DASD data set, is this data set scratched when the data set is deleted?"
             },
             {
                 "field-name": "DSBD_SECLABEL",
@@ -3713,7 +3713,7 @@
             }
         ]
     },
-    "Data set categories record ": {
+    "data-set-categories-record": {
         "record-type": "0401",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/dsr.htm",
         "offsets": [
@@ -3722,7 +3722,7 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the Data Set Categories record\n(0401)."
+                "field-desc": "Record type of the Data Set Categories record (0401)."
             },
             {
                 "field-name": "DSCAT_NAME",
@@ -3736,7 +3736,7 @@
                 "type": "Char",
                 "start": "51",
                 "end": "56",
-                "field-desc": null
+                "field-desc": "Volume upon which this data set resides. Blank if the profile is generic, and "
             },
             {
                 "field-name": "DSCAT_CATEGORY",
@@ -3747,7 +3747,7 @@
             }
         ]
     },
-    "Data set conditional access record ": {
+    "data-set-conditional-access-record": {
         "record-type": "0402",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/dsr.htm",
         "offsets": [
@@ -3756,7 +3756,7 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the Data Set Conditional Access\nrecord (0402)."
+                "field-desc": "Record type of the Data Set Conditional Access record (0402)."
             },
             {
                 "field-name": "DSCACC_NAME",
@@ -3770,35 +3770,35 @@
                 "type": "Char",
                 "start": "51",
                 "end": "56",
-                "field-desc": null
+                "field-desc": "Volume upon which this data set resides. Blank if the profile is generic, and "
             },
             {
                 "field-name": "DSCACC_CATYPE",
                 "type": "Char",
                 "start": "58",
                 "end": "65",
-                "field-desc": null
+                "field-desc": "The type of conditional access checking that is being performed. Valid values are "
             },
             {
                 "field-name": "DSCACC_CANAME",
                 "type": "Char",
                 "start": "67",
                 "end": "74",
-                "field-desc": "The name of a conditional access element that\nis permitted access."
+                "field-desc": "The name of a conditional access element that is permitted access."
             },
             {
                 "field-name": "DSCACC_AUTH_ID",
                 "type": "Char",
                 "start": "76",
                 "end": "83",
-                "field-desc": "The user ID or group name that is authorized to\nthe data set."
+                "field-desc": "The user ID or group name that is authorized to the data set."
             },
             {
                 "field-name": "DSCACC_ACCESS",
                 "type": "Char",
                 "start": "85",
                 "end": "92",
-                "field-desc": null
+                "field-desc": "The access of the conditional access element/user combination. Valid values are "
             },
             {
                 "field-name": "DSCACC_ACCESS_CNT",
@@ -3823,7 +3823,7 @@
             }
         ]
     },
-    "Data set volumes record ": {
+    "data-set-volumes-record": {
         "record-type": "0403",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/dsr.htm",
         "offsets": [
@@ -3857,7 +3857,7 @@
             }
         ]
     },
-    "Data set access record ": {
+    "data-set-access-record": {
         "record-type": "0404",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/dsr.htm",
         "offsets": [
@@ -3880,21 +3880,21 @@
                 "type": "Char",
                 "start": "51",
                 "end": "56",
-                "field-desc": null
+                "field-desc": "Volume upon which this data set resides. Blank if the profile is generic, and "
             },
             {
                 "field-name": "DSACC_AUTH_ID",
                 "type": "Char",
                 "start": "58",
                 "end": "65",
-                "field-desc": "The user ID or group name that is authorized to\nthe data set."
+                "field-desc": "The user ID or group name that is authorized to the data set."
             },
             {
                 "field-name": "DSACC_ACCESS",
                 "type": "Char",
                 "start": "67",
                 "end": "74",
-                "field-desc": null
+                "field-desc": "The access allowed to the user. Valid values are "
             },
             {
                 "field-name": "DSACC_ACCESS_CNT",
@@ -3905,7 +3905,7 @@
             }
         ]
     },
-    "Data set installation data record ": {
+    "data-set-installation-data-record": {
         "record-type": "0405",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/dsr.htm",
         "offsets": [
@@ -3914,7 +3914,7 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the Data Set Installation Data\nRecord (0405)."
+                "field-desc": "Record type of the Data Set Installation Data Record (0405)."
             },
             {
                 "field-name": "DSINSTD_NAME",
@@ -3928,7 +3928,7 @@
                 "type": "Char",
                 "start": "51",
                 "end": "56",
-                "field-desc": null
+                "field-desc": "Volume upon which this data set resides. Blank if the profile is generic, and "
             },
             {
                 "field-name": "DSINSTD_USR_NAME",
@@ -3949,11 +3949,11 @@
                 "type": "Char",
                 "start": "323",
                 "end": "330",
-                "field-desc": null
+                "field-desc": "The flag for the installation-defined field in the form "
             }
         ]
     },
-    "Data set member record ": {
+    "data-set-member-record": {
         "record-type": "0406",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/dsr.htm",
         "offsets": [
@@ -3976,7 +3976,7 @@
                 "type": "Char",
                 "start": "51",
                 "end": "56",
-                "field-desc": null
+                "field-desc": "Volume upon which this data set resides. Blank if the profile is generic, and "
             },
             {
                 "field-name": "DSMEM_MEMBER_NAME",
@@ -3997,11 +3997,11 @@
                 "type": "Char",
                 "start": "76",
                 "end": "83",
-                "field-desc": "The access that is allowed to the ID. Valid values are \"NONE\", \"READ\", \"UPDATE\",\nand \"CONTROL\"."
+                "field-desc": "The access that is allowed to the ID. Valid values are \"NONE\", \"READ\", \"UPDATE\", and \"CONTROL\"."
             }
         ]
     },
-    "Data set DFP data record ": {
+    "data-set-dfp-data-record": {
         "record-type": "0410",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/dsr.htm",
         "offsets": [
@@ -4024,7 +4024,7 @@
                 "type": "Char",
                 "start": "51",
                 "end": "56",
-                "field-desc": null
+                "field-desc": "Volume upon which this data set resides. Blank if the profile is generic, and "
             },
             {
                 "field-name": "DSDFP_RESOWNER_ID",
@@ -4038,11 +4038,11 @@
                 "type": "Char",
                 "start": "67",
                 "end": "130",
-                "field-desc": "The label of the ICSF key that is used to encrypt the data of any newly\nallocated data set."
+                "field-desc": "The label of the ICSF key that is used to encrypt the data of any newly allocated data set."
             }
         ]
     },
-    "Data set TME role record ": {
+    "data-set-tme-role-record": {
         "record-type": "0421",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/dsr.htm",
         "offsets": [
@@ -4065,7 +4065,7 @@
                 "type": "Char",
                 "start": "51",
                 "end": "56",
-                "field-desc": null
+                "field-desc": "Volume upon which this data set resides. Blank if the profile is generic, and "
             },
             {
                 "field-name": "DSTME_ROLE_NAME",
@@ -4079,7 +4079,7 @@
                 "type": "Char",
                 "start": "305",
                 "end": "312",
-                "field-desc": "Access permission to this resource as defined\nby the role."
+                "field-desc": "Access permission to this resource as defined by the role."
             },
             {
                 "field-name": "DSTME_COND_CLASS",
@@ -4097,7 +4097,7 @@
             }
         ]
     },
-    "Data set CSDATA record ": {
+    "data-set-csdata-record": {
         "record-type": "0431",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/dsr.htm",
         "offsets": [
@@ -4120,7 +4120,7 @@
                 "type": "Char",
                 "start": "51",
                 "end": "56",
-                "field-desc": "Volume upon which this data set resides. Blank if the profile is generic, and\n*MODEL if the profile is a model profile."
+                "field-desc": "Volume upon which this data set resides. Blank if the profile is generic, and *MODEL if the profile is a model profile."
             },
             {
                 "field-name": "DSCSD_TYPE",
@@ -4145,7 +4145,7 @@
             }
         ]
     },
-    "General resource basic data record ": {
+    "general-resource-basic-data-record": {
         "record-type": "0500",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -4154,28 +4154,28 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the General Resource Basic Data\nrecord (0500)."
+                "field-desc": "Record type of the General Resource Basic Data record (0500)."
             },
             {
                 "field-name": "GRBD_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": null
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRBD_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource\nprofile belongs."
+                "field-desc": "Name of the class to which the general resource profile belongs."
             },
             {
                 "field-name": "GRBD_GENERIC",
                 "type": "Char",
                 "start": "262",
                 "end": "265",
-                "field-desc": "Is this a generic profile? Valid Values include\n\"Yes\" and \"No\"."
+                "field-desc": "Is this a generic profile? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRBD_CLASS",
@@ -4217,42 +4217,42 @@
                 "type": "Int",
                 "start": "313",
                 "end": "317",
-                "field-desc": "The number of times that the resource was accessed\nwith ALTER authority."
+                "field-desc": "The number of times that the resource was accessed with ALTER authority."
             },
             {
                 "field-name": "GRBD_CONTROL_CNT",
                 "type": "Int",
                 "start": "319",
                 "end": "323",
-                "field-desc": "The number of times that the resource was accessed\nwith CONTROL authority."
+                "field-desc": "The number of times that the resource was accessed with CONTROL authority."
             },
             {
                 "field-name": "GRBD_UPDATE_CNT",
                 "type": "Int",
                 "start": "325",
                 "end": "329",
-                "field-desc": "The number of times that the resource was accessed\nwith UPDATE authority."
+                "field-desc": "The number of times that the resource was accessed with UPDATE authority."
             },
             {
                 "field-name": "GRBD_READ_CNT",
                 "type": "Int",
                 "start": "331",
                 "end": "335",
-                "field-desc": "The number of times that the resource was accessed\nwith READ authority."
+                "field-desc": "The number of times that the resource was accessed with READ authority."
             },
             {
                 "field-name": "GRBD_UACC",
                 "type": "Char",
                 "start": "337",
                 "end": "344",
-                "field-desc": null
+                "field-desc": "The universal access of this resource. For profiles in classes other than DIGTCERT, the valid values are "
             },
             {
                 "field-name": "GRBD_AUDIT_LEVEL",
                 "type": "Char",
                 "start": "346",
                 "end": "353",
-                "field-desc": null
+                "field-desc": "Indicates the level of resource-owner-specified auditing that is performed. Valid values are "
             },
             {
                 "field-name": "GRBD_LEVEL",
@@ -4266,7 +4266,7 @@
                 "type": "Char",
                 "start": "359",
                 "end": "366",
-                "field-desc": null
+                "field-desc": "Indicates the level of auditor-specified auditing that is performed. Valid values are "
             },
             {
                 "field-name": "GRBD_INSTALL_DATA",
@@ -4280,56 +4280,56 @@
                 "type": "Char",
                 "start": "624",
                 "end": "631",
-                "field-desc": null
+                "field-desc": "The resource-owner-specified successful access audit qualifier. This is set to blanks if "
             },
             {
                 "field-name": "GRBD_AUDIT_FAQUAL",
                 "type": "Char",
                 "start": "633",
                 "end": "640",
-                "field-desc": null
+                "field-desc": "The resource-owner-specified failing access audit qualifier. This is set to blanks if "
             },
             {
                 "field-name": "GRBD_GAUDIT_OKQUAL",
                 "type": "Char",
                 "start": "642",
                 "end": "649",
-                "field-desc": null
+                "field-desc": "The auditor-specified successful access audit qualifier. This is set to blanks if "
             },
             {
                 "field-name": "GRBD_GAUDIT_FAQUAL",
                 "type": "Char",
                 "start": "651",
                 "end": "658",
-                "field-desc": null
+                "field-desc": "The auditor-specified failing access audit qualifier. This is set to blanks if "
             },
             {
                 "field-name": "GRBD_WARNING",
                 "type": "Char",
                 "start": "660",
                 "end": "663",
-                "field-desc": "Does this resource have the WARNING attribute?\nValid Values include \"Yes\" and \"No\"."
+                "field-desc": "Does this resource have the WARNING attribute? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRBD_SINGLEDS",
                 "type": "Char",
                 "start": "665",
                 "end": "668",
-                "field-desc": "If this is a TAPEVOL profile, is there only one\ndata set on this tape? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "If this is a TAPEVOL profile, is there only one data set on this tape? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRBD_AUTO",
                 "type": "Char",
                 "start": "670",
                 "end": "673",
-                "field-desc": "If this is a TAPEVOL profile, is the TAPEVOL protection\nautomatic? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "If this is a TAPEVOL profile, is the TAPEVOL protection automatic? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRBD_TVTOC",
                 "type": "Char",
                 "start": "675",
                 "end": "678",
-                "field-desc": "If this is a TAPEVOL profile, is there a tape\nvolume table of contents on this tape? Valid Values include \"Yes\"\nand \"No\"."
+                "field-desc": "If this is a TAPEVOL profile, is there a tape volume table of contents on this tape? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRBD_NOTIFY_ID",
@@ -4343,49 +4343,49 @@
                 "type": "Char",
                 "start": "689",
                 "end": "692",
-                "field-desc": "Can the terminal be used on Sunday? Valid Values\ninclude \"Yes\" and \"No\"."
+                "field-desc": "Can the terminal be used on Sunday? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRBD_ACCESS_MON",
                 "type": "Char",
                 "start": "694",
                 "end": "697",
-                "field-desc": "Can the terminal be used on Monday? Valid Values\ninclude \"Yes\" and \"No\"."
+                "field-desc": "Can the terminal be used on Monday? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRBD_ACCESS_TUE",
                 "type": "Char",
                 "start": "699",
                 "end": "702",
-                "field-desc": "Can the terminal be used on Tuesday? Valid Values\ninclude \"Yes\" and \"No\"."
+                "field-desc": "Can the terminal be used on Tuesday? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRBD_ACCESS_WED",
                 "type": "Char",
                 "start": "704",
                 "end": "707",
-                "field-desc": "Can the terminal be used on Wednesday? Valid Values\ninclude \"Yes\" and \"No\"."
+                "field-desc": "Can the terminal be used on Wednesday? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRBD_ACCESS_THU",
                 "type": "Char",
                 "start": "709",
                 "end": "712",
-                "field-desc": "Can the terminal be used on Thursday? Valid Values\ninclude \"Yes\" and \"No\"."
+                "field-desc": "Can the terminal be used on Thursday? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRBD_ACCESS_FRI",
                 "type": "Char",
                 "start": "714",
                 "end": "717",
-                "field-desc": "Can the terminal be used on Friday? Valid Values\ninclude \"Yes\" and \"No\"."
+                "field-desc": "Can the terminal be used on Friday? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRBD_ACCESS_SAT",
                 "type": "Char",
                 "start": "719",
                 "end": "722",
-                "field-desc": "Can the terminal be used on Saturday? Valid Values\ninclude \"Yes\" and \"No\"."
+                "field-desc": "Can the terminal be used on Saturday? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRBD_START_TIME",
@@ -4399,21 +4399,21 @@
                 "type": "Time",
                 "start": "733",
                 "end": "740",
-                "field-desc": "After what time can a user not logon from this\nterminal?"
+                "field-desc": "After what time can a user not logon from this terminal?"
             },
             {
                 "field-name": "GRBD_ZONE_OFFSET",
                 "type": "Char",
                 "start": "742",
                 "end": "746",
-                "field-desc": null
+                "field-desc": "Time zone in which the terminal is located. Expressed as "
             },
             {
                 "field-name": "GRBD_ZONE_DIRECT",
                 "type": "Char",
                 "start": "748",
                 "end": "748",
-                "field-desc": null
+                "field-desc": "The direction of the time zone shift. Valid values are "
             },
             {
                 "field-name": "GRBD_SECLEVEL",
@@ -4438,7 +4438,7 @@
             }
         ]
     },
-    "General resource tape volume data record ": {
+    "general-resource-tape-volume-data-record": {
         "record-type": "0501",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -4447,21 +4447,21 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the General Resource Tape Volume\nData record (0501)."
+                "field-desc": "Record type of the General Resource Tape Volume Data record (0501)."
             },
             {
                 "field-name": "GRTVOL_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken from the profile\nname."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRTVOL_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": null
+                "field-desc": "Name of the class to which the general resource profile belongs, namely "
             },
             {
                 "field-name": "GRTVOL_SEQUENCE",
@@ -4482,14 +4482,14 @@
                 "type": "Char",
                 "start": "279",
                 "end": "282",
-                "field-desc": "Does a discrete profile exist? Valid Values include\n\"Yes\" and \"No\"."
+                "field-desc": "Does a discrete profile exist? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRTVOL_INTERN_NAME",
                 "type": "Char",
                 "start": "284",
                 "end": "327",
-                "field-desc": "The RACF internal\ndata set name."
+                "field-desc": "The RACF internal data set name."
             },
             {
                 "field-name": "GRTVOL_INTERN_VOLS",
@@ -4503,11 +4503,11 @@
                 "type": "Char",
                 "start": "585",
                 "end": "628",
-                "field-desc": "The data set name used when creating the data\nset."
+                "field-desc": "The data set name used when creating the data set."
             }
         ]
     },
-    "General resource categories record ": {
+    "general-resource-categories-record": {
         "record-type": "0502",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -4516,21 +4516,21 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the General Resources Categories\nrecord (0502)."
+                "field-desc": "Record type of the General Resources Categories record (0502)."
             },
             {
                 "field-name": "GRCAT_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken from the profile\nname."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRCAT_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource\nprofile belongs."
+                "field-desc": "Name of the class to which the general resource profile belongs."
             },
             {
                 "field-name": "GRCAT_CATEGORY",
@@ -4541,7 +4541,7 @@
             }
         ]
     },
-    "General resource members record ": {
+    "general-resource-members-record": {
         "record-type": "0503",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -4550,74 +4550,74 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the General Resource Members record\n(0503)."
+                "field-desc": "Record type of the General Resource Members record (0503)."
             },
             {
                 "field-name": "GRMEM_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken from the profile\nname."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRMEM_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource\nprofile belongs."
+                "field-desc": "Name of the class to which the general resource profile belongs."
             },
             {
                 "field-name": "GRMEM_MEMBER",
                 "type": "Char",
                 "start": "262",
                 "end": "516",
-                "field-desc": null
+                "field-desc": "Member value for this general resource. "
             },
             {
                 "field-name": "GRMEM_GLOBAL_ACC",
                 "type": "Char",
                 "start": "518",
                 "end": "525",
-                "field-desc": null
+                "field-desc": "If this is a "
             },
             {
                 "field-name": "GRMEM_PADS_DATA",
                 "type": "Char",
                 "start": "527",
                 "end": "534",
-                "field-desc": null
+                "field-desc": "If this is a PROGRAM profile, this field contains the Program Access to Data Set (PADS) information for the profile. Valid values are "
             },
             {
                 "field-name": "GRMEM_VOL_NAME",
                 "type": "Char",
                 "start": "536",
                 "end": "541",
-                "field-desc": "If this is a PROGRAM profile, this field defines\nthe volume upon which the program resides."
+                "field-desc": "If this is a PROGRAM profile, this field defines the volume upon which the program resides."
             },
             {
                 "field-name": "GRMEM_VMEVENT_DATA",
                 "type": "Char",
                 "start": "543",
                 "end": "547",
-                "field-desc": null
+                "field-desc": "If this is a VMXEVENT profile, this field defines the level of auditing that is being performed. Valid values are "
             },
             {
                 "field-name": "GRMEM_SECLEVEL",
                 "type": "Int",
                 "start": "549",
                 "end": "553",
-                "field-desc": "If this is a SECLEVEL profile in the SECDATA class,\nthis is the numeric security level that is associated with the SECLEVEL."
+                "field-desc": "If this is a SECLEVEL profile in the SECDATA class, this is the numeric security level that is associated with the SECLEVEL."
             },
             {
                 "field-name": "GRMEM_CATEGORY",
                 "type": "Int",
                 "start": "555",
                 "end": "559",
-                "field-desc": "If this is a CATEGORY profile in the SECDATA class,\nthis is the numeric category that is associated with the CATEGORY."
+                "field-desc": "If this is a CATEGORY profile in the SECDATA class, this is the numeric category that is associated with the CATEGORY."
             }
         ]
     },
-    "General resource volumes record ": {
+    "general-resource-volumes-record": {
         "record-type": "0504",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -4626,21 +4626,21 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the General Resources Volumes record\n(0504)."
+                "field-desc": "Record type of the General Resources Volumes record (0504)."
             },
             {
                 "field-name": "GRVOL_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken from the profile\nname."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRVOL_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": null
+                "field-desc": "Name of the class to which the general resource profile belongs, namely "
             },
             {
                 "field-name": "GRVOL_VOL_NAME",
@@ -4651,7 +4651,7 @@
             }
         ]
     },
-    "General resource access record ": {
+    "general-resource-access-record": {
         "record-type": "0505",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -4660,35 +4660,35 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the General Resource Access record\n(0505)."
+                "field-desc": "Record type of the General Resource Access record (0505)."
             },
             {
                 "field-name": "GRACC_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken from the profile\nname."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRACC_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource\nprofile belongs."
+                "field-desc": "Name of the class to which the general resource profile belongs."
             },
             {
                 "field-name": "GRACC_AUTH_ID",
                 "type": "Char",
                 "start": "262",
                 "end": "269",
-                "field-desc": "User ID or group name which is authorized to use\nthe general resource."
+                "field-desc": "User ID or group name which is authorized to use the general resource."
             },
             {
                 "field-name": "GRACC_ACCESS",
                 "type": "Char",
                 "start": "271",
                 "end": "278",
-                "field-desc": null
+                "field-desc": "The authority that the user or group has over the resource. Valid values are "
             },
             {
                 "field-name": "GRACC_ACCESS_CNT",
@@ -4699,7 +4699,7 @@
             }
         ]
     },
-    "General resource installation data record ": {
+    "general-resource-installation-data-record": {
         "record-type": "0506",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -4708,21 +4708,21 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the General Resource Installation\nData record (0506)."
+                "field-desc": "Record type of the General Resource Installation Data record (0506)."
             },
             {
                 "field-name": "GRINSTD_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken from the profile\nname."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRINSTD_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource\nprofile belongs."
+                "field-desc": "Name of the class to which the general resource profile belongs."
             },
             {
                 "field-name": "GRINSTD_USR_NAME",
@@ -4743,11 +4743,11 @@
                 "type": "Char",
                 "start": "527",
                 "end": "534",
-                "field-desc": null
+                "field-desc": "The flag for the installation-defined field in the form "
             }
         ]
     },
-    "General resource conditional access record ": {
+    "general-resource-conditional-access-record": {
         "record-type": "0507",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -4756,56 +4756,56 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the General Resources Conditional\nAccess record (0507)."
+                "field-desc": "Record type of the General Resources Conditional Access record (0507)."
             },
             {
                 "field-name": "GRCACC_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken from the profile\nname."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRCACC_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource\nprofile belongs."
+                "field-desc": "Name of the class to which the general resource profile belongs."
             },
             {
                 "field-name": "GRCACC_CATYPE",
                 "type": "Char",
                 "start": "262",
                 "end": "269",
-                "field-desc": null
+                "field-desc": "The type of conditional access checking that is being performed. Valid values are "
             },
             {
                 "field-name": "GRCACC_CANAME",
                 "type": "Char",
                 "start": "271",
                 "end": "278",
-                "field-desc": "The name of a conditional access element which\nis permitted access."
+                "field-desc": "The name of a conditional access element which is permitted access."
             },
             {
                 "field-name": "GRCACC_AUTH_ID",
                 "type": "Char",
                 "start": "280",
                 "end": "287",
-                "field-desc": "The user ID or group name which has authority\nto the general resource."
+                "field-desc": "The user ID or group name which has authority to the general resource."
             },
             {
                 "field-name": "GRCACC_ACCESS",
                 "type": "Char",
                 "start": "289",
                 "end": "296",
-                "field-desc": null
+                "field-desc": "The authority of the conditional access element/user combination. Valid values are "
             },
             {
                 "field-name": "GRCACC_ACCESS_CNT",
                 "type": "Int",
                 "start": "298",
                 "end": "302",
-                "field-desc": "The number of times that the general resource\nwas accessed."
+                "field-desc": "The number of times that the general resource was accessed."
             },
             {
                 "field-name": "GRCACC_NET_ID",
@@ -4823,7 +4823,7 @@
             }
         ]
     },
-    "General resource filter data record ": {
+    "general-resource-filter-data-record": {
         "record-type": "0508",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -4839,14 +4839,14 @@
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken from the profile\nname."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRFLTR_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource\nprofile belongs."
+                "field-desc": "Name of the class to which the general resource profile belongs."
             },
             {
                 "field-name": "GRFLTR_LABEL",
@@ -4860,25 +4860,25 @@
                 "type": "Char",
                 "start": "295",
                 "end": "302",
-                "field-desc": "The status of this filter (TRUST) for filters\nthat are trusted."
+                "field-desc": "The status of this filter (TRUST) for filters that are trusted."
             },
             {
                 "field-name": "GRFLTR_USER",
                 "type": "Char",
                 "start": "304",
                 "end": "549",
-                "field-desc": "The user ID or criteria profile name associated\nwith this filter."
+                "field-desc": "The user ID or criteria profile name associated with this filter."
             },
             {
                 "field-name": "GRFLTR_CREATE_NAME",
                 "type": "Char",
                 "start": "551",
                 "end": "1061",
-                "field-desc": null
+                "field-desc": "The issuer's or subject's name, or both, used to create this profile. "
             }
         ]
     },
-    "General resource distributed identity mapping data record ": {
+    "general-resource-distributed-identity-mapping-data-record": {
         "record-type": "0509",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -4887,21 +4887,21 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record Type of the General Resource Distributed\nIdentity Mapping Data record (0509)."
+                "field-desc": "Record Type of the General Resource Distributed Identity Mapping Data record (0509)."
             },
             {
                 "field-name": "GRDMAP_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": null
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRDMAP_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource\nprofile belongs."
+                "field-desc": "Name of the class to which the general resource profile belongs."
             },
             {
                 "field-name": "GRDMAP_LABEL",
@@ -4922,11 +4922,11 @@
                 "type": "Char",
                 "start": "304",
                 "end": "558",
-                "field-desc": null
+                "field-desc": "The registry name value associated with this mapping."
             }
         ]
     },
-    "General resource session data record ": {
+    "general-resource-session-data-record": {
         "record-type": "0510",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -4935,21 +4935,21 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the General Resources Session Data\nrecord (0510)."
+                "field-desc": "Record type of the General Resources Session Data record (0510)."
             },
             {
                 "field-name": "GRSES_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken from the profile\nname."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRSES_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": null
+                "field-desc": "Name of the class to which the general resource profile belongs, namely "
             },
             {
                 "field-name": "GRSES_SESSION_KEY",
@@ -4963,7 +4963,7 @@
                 "type": "Char",
                 "start": "271",
                 "end": "274",
-                "field-desc": "Is the profile locked? Valid Values include \"Yes\"\nand \"No\"."
+                "field-desc": "Is the profile locked? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRSES_KEY_DATE",
@@ -4984,7 +4984,7 @@
                 "type": "Int",
                 "start": "293",
                 "end": "297",
-                "field-desc": "Current\u00ae number of failed attempts."
+                "field-desc": "Current  number of failed attempts."
             },
             {
                 "field-name": "GRSES_MAX_FAIL",
@@ -4998,11 +4998,11 @@
                 "type": "Char",
                 "start": "305",
                 "end": "312",
-                "field-desc": null
+                "field-desc": "Specifies the security checking performed when sessions are established. Valid values are "
             }
         ]
     },
-    "General resource session entities record ": {
+    "general-resource-session-entities-record": {
         "record-type": "0511",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -5011,21 +5011,21 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the General Resources Session Entities\nrecord (0511)."
+                "field-desc": "Record type of the General Resources Session Entities record (0511)."
             },
             {
                 "field-name": "GRSESE_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken from the profile\nname."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRSESE_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": null
+                "field-desc": "Name of the class to which the general resource profile belongs, namely "
             },
             {
                 "field-name": "GRSESE_ENTITY_NAME",
@@ -5043,7 +5043,7 @@
             }
         ]
     },
-    "General resource DLF data record ": {
+    "general-resource-dlf-data-record": {
         "record-type": "0520",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -5052,32 +5052,32 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the General Resources DLF Data\nrecord (0520)."
+                "field-desc": "Record type of the General Resources DLF Data record (0520)."
             },
             {
                 "field-name": "GRDLF_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken from the profile\nname."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRDLF_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": null
+                "field-desc": "Name of the class to which the general resource profile belongs, namely "
             },
             {
                 "field-name": "GRDLF_RETAIN",
                 "type": "Char",
                 "start": "262",
                 "end": "265",
-                "field-desc": "Is this a retained resource? Valid Values include\n\"Yes\" and \"No\"."
+                "field-desc": "Is this a retained resource? Valid Values include \"Yes\" and \"No\"."
             }
         ]
     },
-    "General resource DLF job names record ": {
+    "general-resource-dlf-job-names-record": {
         "record-type": "0521",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -5086,21 +5086,21 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the General Resources DLF Job Names\nrecord (0521)."
+                "field-desc": "Record type of the General Resources DLF Job Names record (0521)."
             },
             {
                 "field-name": "GRDLFJ_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken from the profile\nname."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRDLFJ_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": null
+                "field-desc": "Name of the class to which the general resource profile belongs, namely "
             },
             {
                 "field-name": "GRDLFJ_JOB_NAME",
@@ -5111,7 +5111,7 @@
             }
         ]
     },
-    "General resource SSIGNON data record ": {
+    "general-resource-ssignon-data-record": {
         "record-type": "0530",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -5141,31 +5141,31 @@
                 "type": "Char",
                 "start": "262",
                 "end": "325",
-                "field-desc": null
+                "field-desc": " "
             },
             {
-                "field-name": "GRSIGN _KEY_LABEL",
+                "field-name": "GRSIGN_KEY_LABEL",
                 "type": "Char",
                 "start": "327",
                 "end": "390",
                 "field-desc": "The enhanced PassTicket ICSF CKDS Key Label name."
             },
             {
-                "field-name": "GRSIGN _TYPE",
+                "field-name": "GRSIGN_TYPE",
                 "type": "Char",
                 "start": "392",
                 "end": "403",
                 "field-desc": "Enhanced PassTicket type."
             },
             {
-                "field-name": "GRSIGN _TIMEOUT",
+                "field-name": "GRSIGN_TIMEOUT",
                 "type": "Int",
                 "start": "405",
                 "end": "414",
                 "field-desc": "Enhanced PassTicket timeout setting."
             },
             {
-                "field-name": "GRSIGN _REPLAY",
+                "field-name": "GRSIGN_REPLAY",
                 "type": "Char",
                 "start": "416",
                 "end": "419",
@@ -5173,7 +5173,7 @@
             }
         ]
     },
-    "General resource started task data record ": {
+    "general-resource-started-task-data-record": {
         "record-type": "0540",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -5217,25 +5217,25 @@
                 "type": "Char",
                 "start": "280",
                 "end": "283",
-                "field-desc": "Is process to run trusted? Valid Values include\n\"Yes\" and \"No\"."
+                "field-desc": "Is process to run trusted? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRST_PRIVILEGED",
                 "type": "Char",
                 "start": "285",
                 "end": "288",
-                "field-desc": "Is process to run privileged? Valid Values include\n\"Yes\" and \"No\"."
+                "field-desc": "Is process to run privileged? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRST_TRACE",
                 "type": "Char",
                 "start": "290",
                 "end": "293",
-                "field-desc": "Is entry to be traced? Valid Values include \"Yes\"\nand \"No\"."
+                "field-desc": "Is entry to be traced? Valid Values include \"Yes\" and \"No\"."
             }
         ]
     },
-    "General resource SystemView data record ": {
+    "general-resource-systemview-data-record": {
         "record-type": "0550",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -5276,7 +5276,7 @@
             }
         ]
     },
-    "General resource certificate data record ": {
+    "general-resource-certificate-data-record": {
         "record-type": "0560",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -5292,14 +5292,14 @@
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken from the profile\nname."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRCERT_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource\nprofile belongs."
+                "field-desc": "Name of the class to which the general resource profile belongs."
             },
             {
                 "field-name": "GRCERT_START_DATE",
@@ -5320,53 +5320,53 @@
                 "type": "Date",
                 "start": "282",
                 "end": "291",
-                "field-desc": "The date after which this certificate is no longer\nvalid."
+                "field-desc": "The date after which this certificate is no longer valid."
             },
             {
                 "field-name": "GRCERT_END_TIME",
                 "type": "Time",
                 "start": "293",
                 "end": "300",
-                "field-desc": "The time after which this certificate is no longer\nvalid."
+                "field-desc": "The time after which this certificate is no longer valid."
             },
             {
                 "field-name": "GRCERT_KEY_TYPE",
                 "type": "Char",
                 "start": "302",
                 "end": "309",
-                "field-desc": null
+                "field-desc": "The type of key associated with the certificate. Valid values: "
             },
             {
                 "field-name": "GRCERT_KEY_SIZE",
                 "type": "Int",
                 "start": "311",
                 "end": "320",
-                "field-desc": "The size of private key associated with the certificate,\nexpressed in bits."
+                "field-desc": "The size of private key associated with the certificate, expressed in bits."
             },
             {
                 "field-name": "GRCERT_LAST_SERIAL",
                 "type": "Char",
                 "start": "322",
                 "end": "337",
-                "field-desc": "The hexadecimal representation of the low-order\neight bytes of the serial number of the last certificate signed with\nthis key."
+                "field-desc": "The hexadecimal representation of the low-order eight bytes of the serial number of the last certificate signed with this key."
             },
             {
                 "field-name": "GRCERT_RING_SEQN",
                 "type": "Int",
                 "start": "339",
                 "end": "348",
-                "field-desc": "A sequence number for certificates within the\nring."
+                "field-desc": "A sequence number for certificates within the ring."
             },
             {
                 "field-name": "GRCERT_GEN_REQ",
-                "type": "Char ",
+                "type": "Char",
                 "start": "350",
                 "end": "353",
-                "field-desc": "Indicator to show if the certificate\nis used to generate a request. Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Indicator to show if the certificate is used to generate a request. Valid Values include \"Yes\" and \"No\"."
             }
         ]
     },
-    "General resource certificate references record ": {
+    "general-resource-certificate-references-record": {
         "record-type": "0561",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -5375,32 +5375,32 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the Certificate References record\n(0561)."
+                "field-desc": "Record type of the Certificate References record (0561)."
             },
             {
                 "field-name": "CERTR_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken from the profile\nname."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "CERTR_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource\nprofile belongs."
+                "field-desc": "Name of the class to which the general resource profile belongs."
             },
             {
                 "field-name": "CERTR_RING_NAME",
                 "type": "Char",
                 "start": "262",
                 "end": "507",
-                "field-desc": "The name of the profile which represents a key\nring with which this certificate is associated."
+                "field-desc": "The name of the profile which represents a key ring with which this certificate is associated."
             }
         ]
     },
-    "General resource key ring data record ": {
+    "general-resource-key-ring-data-record": {
         "record-type": "0562",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -5416,35 +5416,35 @@
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken from the profile\nname."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "KEYR_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource\nprofile belongs."
+                "field-desc": "Name of the class to which the general resource profile belongs."
             },
             {
                 "field-name": "KEYR_CERT_NAME",
                 "type": "Char",
                 "start": "262",
                 "end": "507",
-                "field-desc": "The name of the profile which contains the certificate\nwhich is in this key ring."
+                "field-desc": "The name of the profile which contains the certificate which is in this key ring."
             },
             {
                 "field-name": "KEYR_CERT_USAGE",
                 "type": "Char",
                 "start": "509",
                 "end": "516",
-                "field-desc": null
+                "field-desc": "The usage of the certificate within the ring. Valid values are "
             },
             {
                 "field-name": "KEYR_CERT_DEFAULT",
                 "type": "Char",
                 "start": "518",
                 "end": "521",
-                "field-desc": "Is this certificate the default certificate within\nthe ring? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Is this certificate the default certificate within the ring? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "KEYR_CERT_LABEL",
@@ -5455,7 +5455,7 @@
             }
         ]
     },
-    "General resource TME data record ": {
+    "general-resource-tme-data-record": {
         "record-type": "0570",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -5464,21 +5464,21 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the general resource TME data record\n(0570)."
+                "field-desc": "Record type of the general resource TME data record (0570)."
             },
             {
                 "field-name": "GRTME_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken from the profile\nname."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRTME_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource\nbelongs."
+                "field-desc": "Name of the class to which the general resource belongs."
             },
             {
                 "field-name": "GRTME_PARENT",
@@ -5489,7 +5489,7 @@
             }
         ]
     },
-    "General resource TME child record ": {
+    "general-resource-tme-child-record": {
         "record-type": "0571",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -5498,21 +5498,21 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the general resource TME child record\n(0571)."
+                "field-desc": "Record type of the general resource TME child record (0571)."
             },
             {
                 "field-name": "GRTMEC_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken from the profile\nname."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRTMEC_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource\nbelongs."
+                "field-desc": "Name of the class to which the general resource belongs."
             },
             {
                 "field-name": "GRTMEC_CHILD",
@@ -5523,7 +5523,7 @@
             }
         ]
     },
-    "General resource TME resource record ": {
+    "general-resource-tme-resource-record": {
         "record-type": "0572",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -5532,21 +5532,21 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the general resource TME resource record\n(0572)."
+                "field-desc": "Record type of the general resource TME resource record (0572)."
             },
             {
                 "field-name": "GRTMER_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken from the profile\nname."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRTMER_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource\nbelongs."
+                "field-desc": "Name of the class to which the general resource belongs."
             },
             {
                 "field-name": "GRTMER_ORIGIN_ROLE",
@@ -5592,7 +5592,7 @@
             }
         ]
     },
-    "General resource TME group record ": {
+    "general-resource-tme-group-record": {
         "record-type": "0573",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -5601,21 +5601,21 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the general resource TME group record\n(0573)."
+                "field-desc": "Record type of the general resource TME group record (0573)."
             },
             {
                 "field-name": "GRTMEG_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken from the profile\nname."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRTMEG_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource\nbelongs."
+                "field-desc": "Name of the class to which the general resource belongs."
             },
             {
                 "field-name": "GRTMEG_GROUP",
@@ -5626,7 +5626,7 @@
             }
         ]
     },
-    "General resource TME role record ": {
+    "general-resource-tme-role-record": {
         "record-type": "0574",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -5635,21 +5635,21 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the general resource TME role record\n(0574)."
+                "field-desc": "Record type of the general resource TME role record (0574)."
             },
             {
                 "field-name": "GRTMEE_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken from the profile\nname."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRTMEE_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource\nbelongs."
+                "field-desc": "Name of the class to which the general resource belongs."
             },
             {
                 "field-name": "GRTMEE_ROLE_NAME",
@@ -5663,7 +5663,7 @@
                 "type": "Char",
                 "start": "509",
                 "end": "516",
-                "field-desc": "Access permission to this resource as defined\nby the role."
+                "field-desc": "Access permission to this resource as defined by the role."
             },
             {
                 "field-name": "GRTMEE_COND_CLASS",
@@ -5681,7 +5681,7 @@
             }
         ]
     },
-    "General resource KERB data record ": {
+    "general-resource-kerb-data-record": {
         "record-type": "0580",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -5690,21 +5690,21 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the general resource KERB segment\nrecord (0580)."
+                "field-desc": "Record type of the general resource KERB segment record (0580)."
             },
             {
                 "field-name": "GRKERB_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken from the profile\nname."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRKERB_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource\nprofile belongs."
+                "field-desc": "Name of the class to which the general resource profile belongs."
             },
             {
                 "field-name": "GRKERB_KERBNAME",
@@ -5746,60 +5746,60 @@
                 "type": "Char",
                 "start": "540",
                 "end": "543",
-                "field-desc": "Is key encryption using DES enabled? Valid Values\ninclude \"Yes\" and \"No\"."
+                "field-desc": "Is key encryption using DES enabled? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRKERB_ENCRYPT_DES3",
                 "type": "Char",
                 "start": "545",
                 "end": "548",
-                "field-desc": "Is key encryption using DES3 enabled? Valid Values\ninclude \"Yes\" and \"No\"."
+                "field-desc": "Is key encryption using DES3 enabled? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRKERB_ENCRYPT_DESD",
                 "type": "Char",
                 "start": "550",
                 "end": "553",
-                "field-desc": "Is key encryption using DES with derivation enabled?\nValid Values include \"Yes\" and \"No\"."
+                "field-desc": "Is key encryption using DES with derivation enabled? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRKERB_ENCRPT_A128",
                 "type": "Char",
                 "start": "555",
                 "end": "558",
-                "field-desc": "Is key encryption using AES128 enabled? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is key encryption using AES128 enabled? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRKERB_ENCRPT_A256",
                 "type": "Char",
                 "start": "560",
                 "end": "563",
-                "field-desc": "Is key encryption using AES256 enabled? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is key encryption using AES256 enabled? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRKERB_ENCRPT_A128SHA2",
                 "type": "Char",
                 "start": "565",
                 "end": "568",
-                "field-desc": "Is key encryption using AES128 SHA2 enabled? Valid Values include \"Yes\" and\n\"No\"."
+                "field-desc": "Is key encryption using AES128 SHA2 enabled? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRKERB_ENCRPT_A256SHA2",
                 "type": "Char",
                 "start": "570",
                 "end": "573",
-                "field-desc": "Is key encryption using AES256 SHA2 enabled? Valid Values include \"Yes\" and\n\"No\"."
+                "field-desc": "Is key encryption using AES256 SHA2 enabled? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRKERB_CHKADDRS",
                 "type": "Char",
                 "start": "620",
                 "end": "623",
-                "field-desc": "Should the Kerberos server check addresses in\ntickets? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Should the Kerberos server check addresses in tickets? Valid Values include \"Yes\" and \"No\"."
             }
         ]
     },
-    "General resource PROXY record ": {
+    "general-resource-proxy-record": {
         "record-type": "0590",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -5808,21 +5808,21 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the general resource PROXY record\n(0590)."
+                "field-desc": "Record type of the general resource PROXY record (0590)."
             },
             {
                 "field-name": "GRPROXY_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken from the profile\nname."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRPROXY_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource\nbelongs."
+                "field-desc": "Name of the class to which the general resource belongs."
             },
             {
                 "field-name": "GRPROXY_LDAP_HOST",
@@ -5840,7 +5840,7 @@
             }
         ]
     },
-    "General resource EIM record ": {
+    "general-resource-eim-record": {
         "record-type": "05A0",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -5849,7 +5849,7 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the general resource EIM segment\nrecord (05A0)."
+                "field-desc": "Record type of the general resource EIM segment record (05A0)."
             },
             {
                 "field-name": "GREIM_NAME",
@@ -5877,10 +5877,10 @@
                 "type": "Char",
                 "start": "1286",
                 "end": "1289",
-                "field-desc": "EIM Enable option. Valid Values include \"Yes\"\nand \"No\"."
+                "field-desc": "EIM Enable option. Valid Values include \"Yes\" and \"No\"."
             },
             {
-                "field-name": "\u00a0",
+                "field-name": "RESERVED",
                 "type": "Char",
                 "start": "1291",
                 "end": "1364",
@@ -5909,7 +5909,7 @@
             }
         ]
     },
-    "General resource alias data record ": {
+    "general-resource-alias-data-record": {
         "record-type": "05B0",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -5918,7 +5918,7 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the general resource ALIAS group\nrecord (05B0)."
+                "field-desc": "Record type of the general resource ALIAS group record (05B0)."
             },
             {
                 "field-name": "GRALIAS_NAME",
@@ -5932,7 +5932,7 @@
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource\nbelongs."
+                "field-desc": "Name of the class to which the general resource belongs."
             },
             {
                 "field-name": "GRALIAS_IPLOOK",
@@ -5943,7 +5943,7 @@
             }
         ]
     },
-    "General resource CDTINFO data record ": {
+    "general-resource-cdtinfo-data-record": {
         "record-type": "05C0",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -5952,21 +5952,21 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the general resource\nCDTINFO data record (05C0)."
+                "field-desc": "Record type of the general resource CDTINFO data record (05C0)."
             },
             {
                 "field-name": "GRCDT_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken\nfrom the profile."
+                "field-desc": "General resource name as taken from the profile."
             },
             {
                 "field-name": "GRCDT_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": null
+                "field-desc": "Name of the class to which the general resource belongs, namely "
             },
             {
                 "field-name": "GRCDT_POSIT",
@@ -6022,130 +6022,130 @@
                 "type": "Char",
                 "start": "321",
                 "end": "324",
-                "field-desc": "Is an alphabetic character allowed in the first\ncharacter of a profile name? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Is an alphabetic character allowed in the first character of a profile name? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRCDT_FIRST_NATL",
                 "type": "Char",
                 "start": "326",
                 "end": "329",
-                "field-desc": "Is a national character allowed in the first\ncharacter of a profile name? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Is a national character allowed in the first character of a profile name? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRCDT_FIRST_NUM",
                 "type": "Char",
                 "start": "331",
                 "end": "334",
-                "field-desc": "Is a numeric character allowed in the first\ncharacter of a profile name? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Is a numeric character allowed in the first character of a profile name? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRCDT_FIRST_SPEC",
                 "type": "Char",
                 "start": "336",
                 "end": "339",
-                "field-desc": "Is a special character allowed in the first\ncharacter of a profile name? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Is a special character allowed in the first character of a profile name? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRCDT_OTHER_ALPHA",
                 "type": "Char",
                 "start": "341",
                 "end": "344",
-                "field-desc": "Is an alphabetic character allowed in other\ncharacters of a profile name? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Is an alphabetic character allowed in other characters of a profile name? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRCDT_OTHER_NATL",
                 "type": "Char",
                 "start": "346",
                 "end": "349",
-                "field-desc": "Is a national character allowed in other characters\nof a profile name? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Is a national character allowed in other characters of a profile name? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRCDT_OTHER_NUM",
                 "type": "Char",
                 "start": "351",
                 "end": "354",
-                "field-desc": "Is a numeric character allowed in other characters\nof a profile name? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Is a numeric character allowed in other characters of a profile name? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRCDT_OTHER_SPEC",
                 "type": "Char",
                 "start": "356",
                 "end": "359",
-                "field-desc": "Is a special character allowed in other characters\nof a profile name? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Is a special character allowed in other characters of a profile name? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRCDT_OPER",
                 "type": "Char",
                 "start": "361",
                 "end": "364",
-                "field-desc": "Is OPERATIONS attribute to be considered? Valid\nValues include \"Yes\" and \"No\"."
+                "field-desc": "Is OPERATIONS attribute to be considered? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRCDT_DEFAULTUACC",
                 "type": "Char",
                 "start": "366",
                 "end": "373",
-                "field-desc": null
+                "field-desc": "Default universal access. Valid values are "
             },
             {
                 "field-name": "GRCDT_RACLIST",
                 "type": "Char",
                 "start": "375",
                 "end": "384",
-                "field-desc": null
+                "field-desc": "RACLIST setting. Valid values are "
             },
             {
                 "field-name": "GRCDT_GENLIST",
                 "type": "Char",
                 "start": "386",
                 "end": "395",
-                "field-desc": null
+                "field-desc": "GENLIST setting. Valid values are "
             },
             {
                 "field-name": "GRCDT_PROF_ALLOW",
                 "type": "Char",
                 "start": "397",
-                "end": "400\u00ae",
-                "field-desc": "Are profiles allowed in the class? Valid Values\ninclude \"Yes\" and \"No\"."
+                "end": "400",
+                "field-desc": "Are profiles allowed in the class? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRCDT_SECL_REQ",
                 "type": "Char",
                 "start": "402",
                 "end": "405",
-                "field-desc": "Are security labels required for the class when\nMLACTIVE is on? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Are security labels required for the class when MLACTIVE is on? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRCDT_MACPROCESS",
                 "type": "Char",
                 "start": "407",
                 "end": "414",
-                "field-desc": null
+                "field-desc": "Type of mandatory access check processing. Valid values are "
             },
             {
                 "field-name": "GRCDT_SIGNAL",
                 "type": "Char",
                 "start": "416",
                 "end": "419",
-                "field-desc": "Is ENF signal to be sent? Valid Values include\n\"Yes\" and \"No\"."
+                "field-desc": "Is ENF signal to be sent? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRCDT_CASE",
                 "type": "Char",
                 "start": "421",
                 "end": "428",
-                "field-desc": null
+                "field-desc": "Case of profile names. Valid values are "
             },
             {
                 "field-name": "GRCDT_GENERIC",
                 "type": "Char",
                 "start": "430",
                 "end": "439",
-                "field-desc": "GENERIC setting. Valid values are ALLOWED and\nDISALLOWED."
+                "field-desc": "GENERIC setting. Valid values are ALLOWED and DISALLOWED."
             }
         ]
     },
-    "General resource ICTX data record ": {
+    "general-resource-ictx-data-record": {
         "record-type": "05D0",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -6154,53 +6154,53 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the general resource\nICTX segment record (05D0)."
+                "field-desc": "Record type of the general resource ICTX segment record (05D0)."
             },
             {
                 "field-name": "GRICTX_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken\nfrom the profile name."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRICTX_CLASS_NAME",
-                "type": "Char\t",
+                "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource\nprofile belongs. "
+                "field-desc": "Name of the class to which the general resource profile belongs. "
             },
             {
                 "field-name": "GRICTX_USEMAP",
                 "type": "Char",
                 "start": "262",
                 "end": "265",
-                "field-desc": "Should the identity cache store an application\nprovided identity mapping? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Should the identity cache store an application provided identity mapping? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRICTX_DOMAP",
-                "type": "Char\t",
+                "type": "Char",
                 "start": "267",
                 "end": "270",
-                "field-desc": "Should the identity cache determine and store\nthe identity mapping? Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Should the identity cache determine and store the identity mapping? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRICTX_MAPREQ",
-                "type": "Char\t\t",
+                "type": "Char",
                 "start": "272",
                 "end": "275",
-                "field-desc": "Is an identity mapping required? Valid Values\ninclude \"Yes\" and \"No\"."
+                "field-desc": "Is an identity mapping required? Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRICTX_MAP_TIMEOUT",
                 "type": "Int",
                 "start": "277",
                 "end": "281",
-                "field-desc": "How long the identity cache should store an\nidentity mapping."
+                "field-desc": "How long the identity cache should store an identity mapping."
             }
         ]
     },
-    "General Resource CFDEF Data record ": {
+    "general-resource-cfdef-data-record": {
         "record-type": "05E0",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -6209,39 +6209,39 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the general resource\nCFDEF data record (05E0)."
+                "field-desc": "Record type of the general resource CFDEF data record (05E0)."
             },
             {
                 "field-name": "GRCFDEF_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken\nfrom the profile name."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRCFDEF_CLASS",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource\nbelongs, namely CFIELD."
+                "field-desc": "Name of the class to which the general resource belongs, namely CFIELD."
             },
             {
                 "field-name": "GRCFDEF_TYPE",
                 "type": "Char",
                 "start": "262",
                 "end": "265",
-                "field-desc": "Data type for the custom field. Valid values\nare CHAR, FLAG, HEX, NUM."
+                "field-desc": "Data type for the custom field. Valid values are CHAR, FLAG, HEX, NUM."
             },
             {
                 "field-name": "GRCFDEF_MAXLEN",
-                "type": "Int\t",
+                "type": "Int",
                 "start": "267",
                 "end": "276",
                 "field-desc": "Maximum length of the custom field."
             },
             {
                 "field-name": "GRCFDEF_MAXVAL",
-                "type": "Int\t\t",
+                "type": "Int",
                 "start": "278",
                 "end": "287",
                 "field-desc": "Maximum value of the custom field."
@@ -6258,14 +6258,14 @@
                 "type": "Char",
                 "start": "300",
                 "end": "307",
-                "field-desc": "Character restriction for the first character.\nValid values are ALPHA, ALPHANUM, ANY, NONATABC, NONATNUM, NUMERIC."
+                "field-desc": "Character restriction for the first character. Valid values are ALPHA, ALPHANUM, ANY, NONATABC, NONATNUM, NUMERIC."
             },
             {
                 "field-name": "GRCFDEF_OTHER",
                 "type": "Char",
                 "start": "309",
                 "end": "316",
-                "field-desc": "Character restriction for other characters.\nValid values are ALPHA, ALPHANUM, ANY, NONATABC, NONATNUM, NUMERIC."
+                "field-desc": "Character restriction for other characters. Valid values are ALPHA, ALPHANUM, ANY, NONATABC, NONATNUM, NUMERIC."
             },
             {
                 "field-name": "GRCFDEF_MIXED",
@@ -6296,15 +6296,15 @@
                 "field-desc": "Name of the REXX exec to validate the custom field value."
             },
             {
-                "field-name": null,
-                "type": null,
-                "start": null,
-                "end": null,
-                "field-desc": null
+                "field-name": "GRCFDEF_ACEE",
+                "type": "Char",
+                "start": "629",
+                "end": "632",
+                "field-desc": "For USER profile fields, is this field to be made available in an ACEE created for the user? Valid values are \"Yes\" and \"No\"."
             }
         ]
     },
-    "General Resource SIGVER data record ": {
+    "general-resource-sigver-data-record": {
         "record-type": "05F0",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -6313,46 +6313,46 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the general resource\nSIGVER data record (05F0)."
+                "field-desc": "Record type of the general resource SIGVER data record (05F0)."
             },
             {
                 "field-name": "GRSIG_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken\nfrom the profile name."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRSIG_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource\nprofile belongs."
+                "field-desc": "Name of the class to which the general resource profile belongs."
             },
             {
                 "field-name": "GRSIG_SIGREQUIRED",
                 "type": "Char",
                 "start": "262",
                 "end": "265",
-                "field-desc": "Signature required. Valid Values include \"Yes\"\nand \"No\"."
+                "field-desc": "Signature required. Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRSIG_FAILLOAD",
                 "type": "Char",
                 "start": "267",
                 "end": "276",
-                "field-desc": "Condition for which load should fail. Valid\nvalues are NEVER, BADSIGONLY, and ANYBAD."
+                "field-desc": "Condition for which load should fail. Valid values are NEVER, BADSIGONLY, and ANYBAD."
             },
             {
                 "field-name": "GRSIG_AUDIT",
                 "type": "Char",
                 "start": "278",
                 "end": "287",
-                "field-desc": "Condition for which RACF should audit. Valid values are NONE, ALL,\nSUCCESS, BADSIGONLY, and ANYBAD."
+                "field-desc": "Condition for which RACF should audit. Valid values are NONE, ALL, SUCCESS, BADSIGONLY, and ANYBAD."
             }
         ]
     },
-    "General Resource ICSF record ": {
+    "general-resource-icsf-record": {
         "record-type": "05G0",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -6361,53 +6361,53 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the general resource\nICSF record (05G0)."
+                "field-desc": "Record type of the general resource ICSF record (05G0)."
             },
             {
                 "field-name": "GRCSF_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken\nfrom the profile name."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRCSF_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource\nprofile belongs."
+                "field-desc": "Name of the class to which the general resource profile belongs."
             },
             {
                 "field-name": "GRCSF_EXPORTABLE",
-                "type": "Char\t",
+                "type": "Char",
                 "start": "262",
                 "end": "273",
-                "field-desc": "Is the symmetric key exportable? Valid values\nare: BYNONE, BYLIST, and BYANY."
+                "field-desc": "Is the symmetric key exportable? Valid values are: BYNONE, BYLIST, and BYANY."
             },
             {
                 "field-name": "GRCSF_USAGE",
                 "type": "Char",
                 "start": "275",
                 "end": "529",
-                "field-desc": "Allowable uses of the asymmetric key. Valid\nvalues are: HANDSHAKE, NOHANDSHAKE, SECUREEXPORT, and NOSECUREEXPORT."
+                "field-desc": "Allowable uses of the asymmetric key. Valid values are: HANDSHAKE, NOHANDSHAKE, SECUREEXPORT, and NOSECUREEXPORT."
             },
             {
                 "field-name": "GRCSF_CPACF_WRAP",
                 "type": "Char",
                 "start": "531",
                 "end": "533",
-                "field-desc": "Specifies whether the encrypted symmetric key\nis eligible to be rewrapped by CP Assist for Cryptographic Function\n(CPACF). Valid Values include \"Yes\" and \"No\"."
+                "field-desc": "Specifies whether the encrypted symmetric key is eligible to be rewrapped by CP Assist for Cryptographic Function (CPACF). Valid Values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRCSF_CPACF_RET",
                 "type": "Char",
                 "start": "535",
                 "end": "537",
-                "field-desc": "Specifies whether the encrypted symmetric keys that are rewrapped by CP Assist\nfor Cryptographic Function (CPACF) are eligible to be returned to an authorized caller."
+                "field-desc": "Specifies whether the encrypted symmetric keys that are rewrapped by CP Assist for Cryptographic Function (CPACF) are eligible to be returned to an authorized caller."
             }
         ]
     },
-    "General Resource ICSF key label record ": {
+    "general-resource-icsf-key-label-record": {
         "record-type": "05G1",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -6416,32 +6416,32 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the general resource\nICSF key label record (05G1)."
+                "field-desc": "Record type of the general resource ICSF key label record (05G1)."
             },
             {
                 "field-name": "GRCSFK_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken\nfrom the profile name."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRCSFK_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource\nprofile belongs."
+                "field-desc": "Name of the class to which the general resource profile belongs."
             },
             {
                 "field-name": "GRCSFK_LABEL",
                 "type": "Char",
                 "start": "262",
                 "end": "325",
-                "field-desc": "ICSF key label of a public key that can be used\nto export this symmetric key."
+                "field-desc": "ICSF key label of a public key that can be used to export this symmetric key."
             }
         ]
     },
-    "General Resource ICSF certificate identifier record ": {
+    "general-resource-icsf-certificate-identifier-record": {
         "record-type": "05G2",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -6450,32 +6450,32 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the general resource\nICSF certificate identifier record (05G2)."
+                "field-desc": "Record type of the general resource ICSF certificate identifier record (05G2)."
             },
             {
                 "field-name": "GRCSFC_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken\nfrom the profile name."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "GRCSFC_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource\nprofile belongs."
+                "field-desc": "Name of the class to which the general resource profile belongs."
             },
             {
                 "field-name": "GRCSFC_LABEL",
                 "type": "Char",
                 "start": "262",
                 "end": "358",
-                "field-desc": "Certificate identifier of a public key that\ncan be used to export this symmetric key."
+                "field-desc": "Certificate identifier of a public key that can be used to export this symmetric key."
             }
         ]
     },
-    "General resource MFA factor definition record ": {
+    "general-resource-mfa-factor-definition-record": {
         "record-type": "05H0",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -6484,7 +6484,7 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the Multifactor factor definition data record\n(05H0)"
+                "field-desc": "Record type of the Multifactor factor definition data record (05H0)"
             },
             {
                 "field-name": "GRMFA_NAME",
@@ -6498,7 +6498,7 @@
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource profile belongs, namely\nMFADEF."
+                "field-desc": "Name of the class to which the general resource profile belongs, namely MFADEF."
             },
             {
                 "field-name": "GRMFA_FACTOR_DATA_LEN",
@@ -6509,7 +6509,7 @@
             }
         ]
     },
-    "General resource MFPOLICY definition record ": {
+    "general-resource-mfpolicy-definition-record": {
         "record-type": "05I0",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -6532,7 +6532,7 @@
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource profile belongs, namely\nMFADEF."
+                "field-desc": "Name of the class to which the general resource profile belongs, namely MFADEF."
             },
             {
                 "field-name": "GRMFP_TOKEN_TIMEOUT",
@@ -6543,14 +6543,14 @@
             },
             {
                 "field-name": "GRMFP_REUSE",
-                "type": "Yes/No",
+                "type": "YesNo",
                 "start": "273",
                 "end": "275",
                 "field-desc": "MFA token reuse setting."
             }
         ]
     },
-    "General resource MFA policy factors record ": {
+    "general-resource-mfa-policy-factors-record": {
         "record-type": "05I1",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -6559,7 +6559,7 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the user Multifactor authentication policy factors record\n(05I1)."
+                "field-desc": "Record type of the user Multifactor authentication policy factors record (05I1)."
             },
             {
                 "field-name": "GRMPF_NAME",
@@ -6573,7 +6573,7 @@
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource profile belongs, namely\nMFADEF."
+                "field-desc": "Name of the class to which the general resource profile belongs, namely MFADEF."
             },
             {
                 "field-name": "GRMPF_POL_FACTOR",
@@ -6584,7 +6584,7 @@
             }
         ]
     },
-    "General resource CSDATA record ": {
+    "general-resource-csdata-record": {
         "record-type": "05J1",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -6632,7 +6632,7 @@
             }
         ]
     },
-    "General resource IDTPARMS definition record ": {
+    "general-resource-idtparms-definition-record": {
         "record-type": "05k0",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -6655,7 +6655,7 @@
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource profile belongs, namely\nIDTDATA."
+                "field-desc": "Name of the class to which the general resource profile belongs, namely IDTDATA."
             },
             {
                 "field-name": "GRIDTP_SIG_TOKEN_NAME",
@@ -6697,7 +6697,7 @@
                 "type": "Char",
                 "start": "353",
                 "end": "355",
-                "field-desc": "Is the IDT allowed for any application? Valid values include \"Yes\" and\n\"No\"."
+                "field-desc": "Is the IDT allowed for any application? Valid values include \"Yes\" and \"No\"."
             },
             {
                 "field-name": "GRIDTP_PROTALLOWED",
@@ -6708,7 +6708,7 @@
             }
         ]
     },
-    "General resource JES data record ": {
+    "general-resource-jes-data-record": {
         "record-type": "05L0",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -6742,7 +6742,7 @@
             }
         ]
     },
-    "General resource certificate information record ": {
+    "general-resource-certificate-information-record": {
         "record-type": "1560",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
@@ -6751,21 +6751,21 @@
                 "type": "Int",
                 "start": "1",
                 "end": "4",
-                "field-desc": "Record type of the general resource\ncertificate information record (1560)."
+                "field-desc": "Record type of the general resource certificate information record (1560)."
             },
             {
                 "field-name": "CERTN_NAME",
                 "type": "Char",
                 "start": "6",
                 "end": "251",
-                "field-desc": "General resource name as taken\nfrom the profile name."
+                "field-desc": "General resource name as taken from the profile name."
             },
             {
                 "field-name": "CERTN_CLASS_NAME",
                 "type": "Char",
                 "start": "253",
                 "end": "260",
-                "field-desc": "Name of the class to which the general resource\nprofile belongs."
+                "field-desc": "Name of the class to which the general resource profile belongs."
             },
             {
                 "field-name": "CERTN_ISSUER_DN",
@@ -6786,7 +6786,7 @@
                 "type": "Char",
                 "start": "2312",
                 "end": "2327",
-                "field-desc": "Certificate signature algorithm.\nValid values are md2RSA, md5RSA, sha1RSA, sha1DSA, sha256RSA, sha224RSA,\nsha384RSA, sha512RSA, sha1ECDSA, sha256ECDSA, sha224ECDSA, sha384ECDSA,\nsha512ECDSA, and UNKNOWN."
+                "field-desc": "Certificate signature algorithm. Valid values are md2RSA, md5RSA, sha1RSA, sha1DSA, sha256RSA, sha224RSA, sha384RSA, sha512RSA, sha1ECDSA, sha256ECDSA, sha224ECDSA, sha384ECDSA, sha512ECDSA, and UNKNOWN."
             },
             {
                 "field-name": "CERTN_CERT_FGRPRNT",


### PR DESCRIPTION
add cleanup offset/description of data before writing offset.json.
verify existence of _parsed['0204'] before issueing save_pickle(), thus preventing key error when no '0204' types were parsed