### PR TITLE
parsing for all record types in unload

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Get all users that have not logged in (on?) since January 1st 2022. And print us
     mysys.parse()
     while mysys.status['status'] != 'Ready':
         time.sleep(5)
+    mysys.correlate()
     selection = mysys.users.loc[mysys.users.USBD_LASTJOB_DATE<="2022-01-01"][['USBD_NAME','USBD_LASTJOB_DATE']]
     for user in selection.values:
       print(f"Userid {user[0]}, last active: {user[1]}")
@@ -160,6 +161,7 @@ Create a neat XLSX
     mysys.parse()
     while mysys.status['status'] != 'Ready':
         time.sleep(5)
+    mysys.correlate()
     mysys.xls('/path/to/my.xlsx')
 
 # Updates 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ Then later, you don't need to parse the same unload again, just do:
     >>> hash(mysys.groups.values.tobytes())
     -8566685915584060910
 
+### Prepare internal data structures for later processing
+
+    >>> mysys.correlate()
 
 ## All functions
 

--- a/README.md
+++ b/README.md
@@ -120,9 +120,11 @@ Then later, you don't need to parse the same unload again, just do:
 | generalAccess | Returns DataFrame with with all accesslists for general resource profiles | mysys.generalAccess
 | generalConditionalAccess | Returns DataFrame with with all conditional accesslists for general resource profiles | mysys.generalConditionalAccess
 | generals | Returns DataFrame with with all general resource profiles | mysys.generals 
+| getdatasetrisk | Returns dict with users that have access or administrative authority on a profile | mysys.getdatasetrisk('SYS1.**') |
 | group | Returns DataFrame with with one dataset profile only | mysys.group('SYS1') |
 | groupConnect | Returns DataFrame with with user group connection records (0203 recordtype) | mysys.groupConnect |
 | groups | Returns DataFrame with all group data | mysys.groups |
+| groupsWithoutUsers | Returns DataFrame with groups that have no connected users | mysys.groupsWithoutUsers |
 | grouptree | Returns dict with groups arranged by superior group | mysys.grouptree() |
 | installdata | Returns DataFrame with with user installation data (0204 recordtype) | mysys.installdata |
 | operations | Returns a DataFrame  with all operations users | mysys.operations |

--- a/README.md
+++ b/README.md
@@ -122,10 +122,14 @@ Then later, you don't need to parse the same unload again, just do:
 | correlate | assigns index columns and prepares data structures for faster reporting | mysys.correlate() |
 | datasetAccess | Returns DataFrame with all Accesslists for all dataset profiles | mysys.datasetsAccess |
 | dataset | Returns DataFrame with selected datasetprofiles | mysys.dataset('SYS1.**','GEN') |
+| datasetPermit | Returns DataFrame with selected permits on datasetprofiles | mysys.datasetPermit(profile=, id=, access=, pattern='G') |
+| datasetConditionalPermit | Returns DataFrame with selected "PERMIT WHEN()" on datasetprofiles | mysys.datasetConditionalPermit(profile=, id=, access=, pattern='G') |
 | datasets | Returns DataFrame with all datasetprofiles | mysys.datasets |
 | generalAccess | Returns DataFrame with with all accesslists for general resource profiles | mysys.generalAccess
 | generalConditionalAccess | Returns DataFrame with with all conditional accesslists for general resource profiles | mysys.generalConditionalAccess
 | general | Returns DataFrame with selected general resource profiles | mysys.general('FACI*','BPX.**','GEN') |
+| generalPermit | Returns DataFrame with selected permits on resource profiles | mysys.generalPermit(resclass=, profile=, id=, access=, pattern='G') |
+| generalConditionalPermit | Returns DataFrame with selected "PERMIT WHEN()" on resource profiles | mysys.generalConditionalPermit(resclass=, profile=, id=, access=, pattern='G') |
 | generals | Returns DataFrame with with all general resource profiles | mysys.generals 
 | getdatasetrisk | Returns dict with users that have access or administrative authority on a profile | mysys.getdatasetrisk('SYS1.**') |
 | group | Returns DataFrame with with group profiles matching selection | mysys.group('SYS1'), or msys.group('SYS*','G') |
@@ -186,12 +190,14 @@ Show group information
     mysys.correlate()
     mysys.connect('SYS*', None, 'G')    # users connected to SYSxxxxx groups
     mysys.general('**', 'IBMUSER', 'G') # connects of user IBMUSER
+    mysys.general(user='IBMUSER', pattern='G') # connects of user IBMUSER
 
 Show access list information
 
     mysys.correlate()
     mysys.datasetPermit('SYS1.**')    # IDs permitted on SYS1.**
-    mysys.datasetPermit('SYS1.**', None, 'ALTER', pattern='G')    # IDs ALTER access on any SYS1 dataset profile
+    mysys.datasetPermit(id='IBMUSER', pattern='GENERIC')    # where is IBMUSER permitted
+    mysys.datasetPermit('SYS1.**', access='ALTER', pattern='G')    # IDs ALTER access on any SYS1 dataset profile
     mysys.generalPermit('XFAC*', 'CKR.**', pattern='G') # permits on zSecure Admin/Audit profile
 
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ To get started with PyRACF, install it using `pip install pyracf` or explore the
 - all known record types parsed and loaded into DataFrames
 - index columns assigned to all DataFrames, assigned by new correlate() method
 - new method correlate() to increase speed of subsequent data access, use after parse() or loading of pickles
-- selection and reporting methods dataset(), group(), general() and user(), accept 
+- selection and reporting methods dataset(), group(), general(), user() and connect(), accepts GENERIC and regex patterns 
+- added GPMEM_AUTH to connectData frame, consolidating all connect info into one line 
 
 ### 0.6.4 (Add 0209)
 - Added 0209 recordtype to parser. (userDistributedMapping)
@@ -114,6 +115,7 @@ Then later, you don't need to parse the same unload again, just do:
 | Function/Property | Explanation | Example |
 |---|---|---|
 | auditors | Returns DataFrame with all user having the auditor bit switched on | mysys.auditors |
+| connect | Returns DataFrame with selected user to group connects | mysys.connect('SYS1',None) or mysys.connect('**','IBM*','G') |
 | connects | Returns DataFrame with all user to group connects | mysys.connects |
 | correlate | assigns index columns and prepares data structures for faster reporting | mysys.correlate() |
 | datasetAccess | Returns DataFrame with all Accesslists for all dataset profiles | mysys.datasetsAccess |
@@ -173,15 +175,17 @@ Create a neat XLSX
 
 Print z/OS UNIX profiles
 
-    import time
-    from pyracf import IRRDBU
-    mysys = IRRDBU('/path/to/irrdbu00')
-    mysys.parse()
-    while mysys.status['status'] != 'Ready':
-        time.sleep(5)
     mysys.correlate()
     mysys.general('FAC*', 'BPX.**', 'G')
     mysys.general('UNIXPRIV', '**', 'G') # print all in UNIXPRIV
+
+Show group information
+
+    mysys.correlate()
+    mysys.connect('SYS*', None, 'G')    # users connected to SYSxxxxx groups
+    mysys.general('**', 'IBMUSER', 'G') # connects of user IBMUSER
+
+
 
 # Updates 
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ To get started with PyRACF, install it using `pip install pyracf` or explore the
 - index columns assigned to all DataFrames, assigned by new correlate() method
 - new method correlate() to increase speed of subsequent data access, use after parse() or loading of pickles
 - selection and reporting methods dataset(), group(), general(), user() and connect(), accepts GENERIC and regex patterns 
+- also datasetPermit and datasetConditionalPermit, with parameters profile(mask), id(mask) and access(mask) 
+- also generalPermit and generalConditionalPermit, with parameters resclass(mask), profile(mask), id(mask) and access(mask)
 - added GPMEM_AUTH to connectData frame, consolidating all connect info into one line 
 
 ### 0.6.4 (Add 0209)
@@ -185,6 +187,12 @@ Show group information
     mysys.connect('SYS*', None, 'G')    # users connected to SYSxxxxx groups
     mysys.general('**', 'IBMUSER', 'G') # connects of user IBMUSER
 
+Show access list information
+
+    mysys.correlate()
+    mysys.datasetPermit('SYS1.**')    # IDs permitted on SYS1.**
+    mysys.datasetPermit('SYS1.**', None, 'ALTER', pattern='G')    # IDs ALTER access on any SYS1 dataset profile
+    mysys.generalPermit('XFAC*', 'CKR.**', pattern='G') # permits on zSecure Admin/Audit profile
 
 
 # Updates 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ To get started with PyRACF, install it using `pip install pyracf` or explore the
 - all known record types parsed and loaded into DataFrames
 - index columns assigned to all DataFrames, assigned by new correlate() method
 - new method correlate() to increase speed of subsequent data access, use after parse() or loading of pickles
+- selection and reporting methods dataset(), group(), general() and user(), accept 
 
 ### 0.6.4 (Add 0209)
 - Added 0209 recordtype to parser. (userDistributedMapping)
@@ -116,12 +117,14 @@ Then later, you don't need to parse the same unload again, just do:
 | connects | Returns DataFrame with all user to group connects | mysys.connects |
 | correlate | assigns index columns and prepares data structures for faster reporting | mysys.correlate() |
 | datasetAccess | Returns DataFrame with all Accesslists for all dataset profiles | mysys.datasetsAccess |
+| dataset | Returns DataFrame with selected datasetprofiles | mysys.dataset('SYS1.**','GEN') |
 | datasets | Returns DataFrame with all datasetprofiles | mysys.datasets |
 | generalAccess | Returns DataFrame with with all accesslists for general resource profiles | mysys.generalAccess
 | generalConditionalAccess | Returns DataFrame with with all conditional accesslists for general resource profiles | mysys.generalConditionalAccess
+| general | Returns DataFrame with selected general resource profiles | mysys.general('FACI*','BPX.**','GEN') |
 | generals | Returns DataFrame with with all general resource profiles | mysys.generals 
 | getdatasetrisk | Returns dict with users that have access or administrative authority on a profile | mysys.getdatasetrisk('SYS1.**') |
-| group | Returns DataFrame with with one dataset profile only | mysys.group('SYS1') |
+| group | Returns DataFrame with with group profiles matching selection | mysys.group('SYS1'), or msys.group('SYS*','G') |
 | groupConnect | Returns DataFrame with with user group connection records (0203 recordtype) | mysys.groupConnect |
 | groups | Returns DataFrame with all group data | mysys.groups |
 | groupsWithoutUsers | Returns DataFrame with groups that have no connected users | mysys.groupsWithoutUsers |
@@ -137,6 +140,8 @@ Then later, you don't need to parse the same unload again, just do:
 | specials | Returns a DataFrame  with all special users | mysys.specials |
 | status | Returns JSON with parsing status | mysys.status |
 | uacc_read_datasets | Returns a DataFrame  with all dataset profiles having UACC=READ | mysys.uacc_read_datasets |
+| user | Returns DataFrame with with user profiles matching selection | mysys.user('IBM*'), or msys.user('SYS.*','REGEX') |
+| users | Returns DataFrame with all user base data | mysys.users |
 | xls | Creates an XLSX with all permits per class | mysys.xls(fileName='myxls.xlsx') |
 
 # Example use-case
@@ -165,6 +170,18 @@ Create a neat XLSX
         time.sleep(5)
     mysys.correlate()
     mysys.xls('/path/to/my.xlsx')
+
+Print z/OS UNIX profiles
+
+    import time
+    from pyracf import IRRDBU
+    mysys = IRRDBU('/path/to/irrdbu00')
+    mysys.parse()
+    while mysys.status['status'] != 'Ready':
+        time.sleep(5)
+    mysys.correlate()
+    mysys.general('FAC*', 'BPX.**', 'G')
+    mysys.general('UNIXPRIV', '**', 'G') # print all in UNIXPRIV
 
 # Updates 
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Then later, you don't need to parse the same unload again, just do:
 | Function/Property | Explanation | Example |
 |---|---|---|
 | auditors | Returns DataFrame with all user having the auditor bit switched on | mysys.auditors |
-| connect | Returns DataFrame with selected user to group connects | mysys.connect('SYS1',None) or mysys.connect('**','IBM*','G') |
+| connect | Returns DataFrame with selected user to group connects | mysys.connect('SYS1',None,'G') or mysys.connect('**','IBM*','G') |
 | connects | Returns DataFrame with all user to group connects | mysys.connects |
 | correlate | assigns index columns and prepares data structures for faster reporting | mysys.correlate() |
 | datasetAccess | Returns DataFrame with all Accesslists for all dataset profiles | mysys.datasetsAccess |

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ To get started with PyRACF, install it using `pip install pyracf` or explore the
 - fixed: record type '0260' in offset.json was malformed
 - updated offsets.json from https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/format.htm etc
 - getOffsets.py to update the json model
+- fixed: RACF documentation contains incorrect record type 05k0
+- all known record types parsed and loaded into DataFrames
+- index columns assigned to all DataFrames, assigned by new correlate() method
+- new method correlate() to increase speed of subsequent data access, use after parse() or loading of pickles
 
 ### 0.6.4 (Add 0209)
 - Added 0209 recordtype to parser. (userDistributedMapping)
@@ -107,6 +111,7 @@ Then later, you don't need to parse the same unload again, just do:
 |---|---|---|
 | auditors | Returns DataFrame with all user having the auditor bit switched on | mysys.auditors |
 | connects | Returns DataFrame with all user to group connects | mysys.connects |
+| correlate | assigns index columns and prepares data structures for faster reporting | mysys.correlate() |
 | datasetAccess | Returns DataFrame with all Accesslists for all dataset profiles | mysys.datasetsAccess |
 | datasets | Returns DataFrame with all datasetprofiles | mysys.datasets |
 | generalAccess | Returns DataFrame with with all accesslists for general resource profiles | mysys.generalAccess
@@ -115,9 +120,11 @@ Then later, you don't need to parse the same unload again, just do:
 | group | Returns DataFrame with with one dataset profile only | mysys.group('SYS1') |
 | groupConnect | Returns DataFrame with with user group connection records (0203 recordtype) | mysys.groupConnect |
 | groups | Returns DataFrame with all group data | mysys.groups |
+| grouptree | Returns dict with groups arranged by superior group | mysys.grouptree() |
 | installdata | Returns DataFrame with with user installation data (0204 recordtype) | mysys.installdata |
 | operations | Returns a DataFrame  with all operations users | mysys.operations |
 | orphans | Returns 2 DataFrames one with orphans in dataset profile access lists, and one for general resources | d, g = mysys.orphans |
+| ownertree | Returns dict with groups arranged by owner group or user ID | mysys.ownertree() |
 | parse | parses the unload. optional specify recordtypes | mysys.parse(recordtypes=['0200']) |
 | parse_fancycli | parses the unload with a fancy cli status update. optional recordtypes can be specified | mysys.parse_fancycli(recorddtypes=['0200']) |
 | revoked | Returns a DataFrame  with all revoked users | mysys.revoked |

--- a/src/pyracf/__init__.py
+++ b/src/pyracf/__init__.py
@@ -324,13 +324,15 @@ class RACF:
             if rtype in thingswewant and rtype in self._records and self._records[rtype]['parsed']>0:
                 if "index" in rinfo:
                     keys = rinfo["index"]
+                    names = [keys[i].replace(rinfo["name"]+"_","") for i in range(len(keys))]
                 elif rtype[1]=="5":  # general resources
                     keys = [rinfo["name"]+"_CLASS_NAME",rinfo["name"]+"_NAME"]
+                    names = ["CLASS_NAME","NAME"]
                 else:
                     keys = rinfo["name"]+"_NAME"
-                none_mask = None if type(keys)==str else [None,None,None][0:len(keys)]
+                    names = "NAME"
                 getattr(self,rinfo['df']).set_index(keys,drop=False,inplace=True)
-                getattr(self,rinfo['df']).rename_axis(none_mask,inplace=True)  # prevent ambigous index / column names 
+                getattr(self,rinfo['df']).rename_axis(names,inplace=True)  # prevent ambiguous index / column names 
         
         
         

--- a/src/pyracf/__init__.py
+++ b/src/pyracf/__init__.py
@@ -60,7 +60,7 @@ class RACF:
     '0201': {'name':'USCAT', 'df':'_userCategories'},
     '0202': {'name':'USCLA', 'df':'_userClasses'},
     '0203': {'name':'USGCON', 'df':'_groupConnect', "index":["USGCON_GRP_ID","USGCON_NAME"]},
-    '0204': {'name':'USINSTD', 'df':'_usrUSRDATA'},
+    '0204': {'name':'USINSTD', 'df':'_userUSRDATA'},
     '0205': {'name':'USCON', 'df':'_connectData', "index":["USCON_GRP_ID","USCON_NAME"]},
     '0206': {'name':'USRSF', 'df':'_userRRSFdata'},
     '0207': {'name':'USCERT', 'df':'_userCERTname'},
@@ -427,7 +427,7 @@ class RACF:
     def installdata(self):
         if self._state != self.STATE_READY:
             raise StoopidException('Not done parsing yet! (PEBKAM/ID-10T error)')
-        return self._installdata
+        return self._userUSRDATA
 
     @property
     def datasets(self):

--- a/src/pyracf/__init__.py
+++ b/src/pyracf/__init__.py
@@ -49,22 +49,101 @@ class RACF:
     _recordtype_info = {
     '0100': {'name':'GPBD', 'df':'_groups'},
     '0101': {'name':'GPSGRP', 'df':'_subgroups'},
-    '0102': {'name':'GPMEM', 'df':'_connects'},
+    '0102': {'name':'GPMEM', 'df':'_connects', "index":["GPMEM_NAME","GPMEM_MEMBER_ID"]},
+    '0103': {'name':'GPINSTD', 'df':'_groupUSRDATA'},
+    '0110': {'name':'GPDFP', 'df':'_groupDFP'},
     '0120': {'name':'GPOMVS', 'df':'_groupOMVS'},
+    '0130': {'name':'GPOVM', 'df':'_groupOVM'},
+    '0141': {'name':'GPTME', 'df':'_groupTME'},
+    '0151': {'name':'GPCSD', 'df':'_groupCSDATA'},
     '0200': {'name':'USBD', 'df':'_users'},
-    '0203': {'name':'USGCON', 'df':'_groupConnect'},
-    '0204': {'name':'USINSTD', 'df':'_installdata'},
-    '0205': {'name':'USCON', 'df':'_connectData'},
+    '0201': {'name':'USCAT', 'df':'_userCategories'},
+    '0202': {'name':'USCLA', 'df':'_userClasses'},
+    '0203': {'name':'USGCON', 'df':'_groupConnect', "index":["USGCON_GRP_ID","USGCON_NAME"]},
+    '0204': {'name':'USINSTD', 'df':'_usrUSRDATA'},
+    '0205': {'name':'USCON', 'df':'_connectData', "index":["USCON_GRP_ID","USCON_NAME"]},
+    '0206': {'name':'USRSF', 'df':'_userRRSFdata'},
+    '0207': {'name':'USCERT', 'df':'_userCERTname'},
+    '0208': {'name':'USNMAP', 'df':'_userAssociatedMappings'},
     '0209': {'name':'USDMAP', 'df':'_userDistributedMapping'},
+    '020A': {'name':'USMFA', 'df':'_userMFAfactor'},
+    '020B': {'name':'USMPOL', 'df':'_userMFApolicies'},
+    '0210': {'name':'USDFP', 'df':'_userDFP'},
     '0220': {'name':'USTSO', 'df':'_userTSO'},
+    '0230': {'name':'USCICS', 'df':'_userCICS'},
+    '0231': {'name':'USCOPC', 'df':'_userCICSoperatorClasses'},
+    '0232': {'name':'USCRSL', 'df':'_userCICSrslKeys'},
+    '0233': {'name':'USCTSL', 'df':'_userCICStslKeys'},
+    '0240': {'name':'USLAN', 'df':'_userLANGUAGE'},
+    '0250': {'name':'USOPR', 'df':'_userOPERPARM'},
+    '0251': {'name':'USOPRP', 'df':'_userOPERPARMscope'},
+    '0260': {'name':'USWRK', 'df':'_userWORKATTR'},
     '0270': {'name':'USOMVS', 'df':'_userOMVS'},
+    '0280': {'name':'USNETV', 'df':'_userNETVIEW'},
+    '0281': {'name':'USNOPC', 'df':'_userNETVIEWopclass'},
+    '0282': {'name':'USNDOM', 'df':'_userNETVIEWdomains'},
+    '0290': {'name':'USDCE', 'df':'_userDCE'},
+    '02A0': {'name':'USOVM', 'df':'_userOVM'},
+    '02B0': {'name':'USLNOT', 'df':'_userLNOTES'},
+    '02C0': {'name':'USNDS', 'df':'_userNDS'},
+    '02D0': {'name':'USKERB', 'df':'_userKERB'},
+    '02E0': {'name':'USPROXY', 'df':'_userPROXY'},
+    '02F0': {'name':'USEIM', 'df':'_userEIM'},
+    '02G1': {'name':'USCSD', 'df':'_userCSDATA'},
+    '1210': {'name':'USMFAC', 'df':'_user-MFAfactorTags'},
     '0400': {'name':'DSBD', 'df':'_datasets'},
+    '0401': {'name':'DSCAT', 'df':'_datasetCategories'},
     '0402': {'name':'DSCACC', 'df':'_datasetConditionalAccess'},
+    '0403': {'name':'DSVOL', 'df':'_datasetVolumes'},
     '0404': {'name':'DSACC', 'df':'_datasetAccess'},
+    '0405': {'name':'DSINSTD', 'df':'_datasetUSRDATA'},
+    '0406': {'name':'DSMEM', 'df':'_datasetMember'},
+    '0410': {'name':'DSDFP', 'df':'_datasetDFP'},
+    '0421': {'name':'DSTME', 'df':'_datasetTME'},
+    '0431': {'name':'DSCSD', 'df':'_datasetCSDATA'},
     '0500': {'name':'GRBD', 'df':'_generals'},
+    '0501': {'name':'GRTVOL', 'df':'_generalTAPEvolume'},
+    '0502': {'name':'GRCAT', 'df':'_generalCategories'},
     '0503': {'name':'GRMEM', 'df':'_generalMembers'},
+    '0504': {'name':'GRVOL', 'df':'_generalVolumes'},
     '0505': {'name':'GRACC', 'df':'_generalAccess'},
-    '0507': {'name':'GRCACC', 'df':'_generalConditionalAccess'}
+    '0506': {'name':'GRINSTD', 'df':'_generalUSRDATA'},
+    '0507': {'name':'GRCACC', 'df':'_generalConditionalAccess'},
+    '0508': {'name':'GRFLTR', 'df':'_generalFILTER'},
+    '0509': {'name':'GRDMAP', 'df':'_generalDistributedMapping'},
+    '0510': {'name':'GRSES', 'df':'_generalSESSION'},
+    '0511': {'name':'GRSESE', 'df':'_generalSESSIONentities'},
+    '0520': {'name':'GRDLF', 'df':'_generalDLF'},
+    '0521': {'name':'GRDLFJ', 'df':'_generalDLFjob-names'},
+    '0530': {'name':'GRSIGN', 'df':'_generalSSIGNON'},
+    '0540': {'name':'GRST', 'df':'_generalSTARTED'},
+    '0550': {'name':'GRSV', 'df':'_generalSYSTEMVIEW'},
+    '0560': {'name':'GRCERT', 'df':'_generalCERT'},
+    '0561': {'name':'CERTR', 'df':'_generalCERTreferences'},
+    '0562': {'name':'KEYR', 'df':'_general-KEYRING'},
+    '0570': {'name':'GRTME', 'df':'_generalTME'},
+    '0571': {'name':'GRTMEC', 'df':'_generalTMEchild'},
+    '0572': {'name':'GRTMER', 'df':'_generalTMEresource'},
+    '0573': {'name':'GRTMEG', 'df':'_generalTMEgroup'},
+    '0574': {'name':'GRTMEE', 'df':'_generalTMErole'},
+    '0580': {'name':'GRKERB', 'df':'_generalKERB'},
+    '0590': {'name':'GRPROXY', 'df':'_generalPROXY'},
+    '05A0': {'name':'GREIM', 'df':'_generalEIM'},
+    '05B0': {'name':'GRALIAS', 'df':'_generalALIAS'},
+    '05C0': {'name':'GRCDT', 'df':'_generalCDTINFO'},
+    '05D0': {'name':'GRICTX', 'df':'_generalICTX'},
+    '05E0': {'name':'GRCFDEF', 'df':'_generalCFDEF', "index":["GRCFDEF_CLASS","GRCFDEF_NAME"]},
+    '05F0': {'name':'GRSIG', 'df':'_generalSIGVER'},
+    '05G0': {'name':'GRCSF', 'df':'_generalICSF'},
+    '05G1': {'name':'GRCSFK', 'df':'_generalICSFkeylabel'},
+    '05G2': {'name':'GRCSFC', 'df':'_generalICSFcertificateIdentifier'},
+    '05H0': {'name':'GRMFA', 'df':'_generalMFAfactor'},
+    '05I0': {'name':'GRMFP', 'df':'_generalMFApolicy'},
+    '05I1': {'name':'GRMPF', 'df':'_generalMFApolicyFactors'},
+    '05J1': {'name':'GRCSD', 'df':'_generalCSDATA'},
+    '05K0': {'name':'GRIDTP', 'df':'_generalIDTFPARMS'},
+    '05L0': {'name':'GRJES', 'df':'_generalJESDATA'},
+    '1560': {'name':'CERTN', 'df':'_generalCERTNAME'}
     }
 
     _recordname_type = {}    # {'GPBD': '0100', ....}
@@ -229,7 +308,29 @@ class RACF:
 
     def parsed(self, rname):
         """ how many records with this name (type) were parsed """
-        return self._records[RACF._recordname_type[rname]]['parsed']
+        rtype = RACF._recordname_type[rname]
+        return self._records[rtype]['parsed'] if rtype in self._records else 0
+        
+    def correlate(self, thingswewant=_recordtype_info.keys()):
+        """ construct tables that combine the raw dataframes for improved processing """
+        self._ownertree = self.ownertree()
+        self._grouptree = self.grouptree()
+
+        if self.parsed("GPMEM") == 0 or self.parsed("USCON") == 0:
+            raise StoopidException("Need to parse GPMEM and USCON first...")
+
+        # set consistent index columns for existing dfs: profile key, connect group+user, of profile class+key (for G.R.)
+        for (rtype,rinfo) in RACF._recordtype_info.items():
+            if rtype in thingswewant and rtype in self._records and self._records[rtype]['parsed']>0:
+                if "index" in rinfo:
+                    keys = rinfo["index"]
+                elif rtype[1]=="5":  # general resources
+                    keys = [rinfo["name"]+"_CLASS_NAME",rinfo["name"]+"_NAME"]
+                else:
+                    keys = rinfo["name"]+"_NAME"
+                getattr(self,rinfo['df']).set_index(keys,drop=False,inplace=True)
+        
+        
         
     def save_pickle(self, df='', dfname='', path='', prefix=''):
         # Sanity check
@@ -550,30 +651,29 @@ class RACF:
 
         writer.close()   
 
-    def tree(self,tree,linkup_field="GPBD_SUPGRP_ID"):
-        if tree == None:
-            # get all owners... (group or user) or all superior groups
-            tree = {}
-            where_is = {}
-            higher_ups = self.groups.groupby(linkup_field)
-            for higher_up in higher_ups.groups.keys():
-                if higher_up not in tree:
-                    tree[higher_up] = []
-                    for group in higher_ups.get_group(higher_up)['GPBD_NAME'].values:
-                        tree[higher_up].append(group)
-                        where_is[group] = tree[higher_up]
-            # initially, for an owner tree, anchor can be a user (like IBMUSER) or a group
-            # now we gotta condense it, so only IBMUSER and other group owning users are at top level
-            # for group tree, we should end up with SYS1, and a list of groups
-            deletes = []
-            for anchor in tree:
-                if anchor in where_is:
-                    supgrpMembers = where_is[anchor]
-                    supgrpMembers.remove(anchor)
-                    supgrpMembers.append({anchor: tree[anchor]})
-                    deletes.append(anchor)
-            for anchor in deletes:
-                tree.pop(anchor)
+    def tree(self,linkup_field="GPBD_SUPGRP_ID"):
+        # get all owners... (group or user) or all superior groups
+        tree = {}
+        where_is = {}
+        higher_ups = self.groups.groupby(linkup_field)
+        for higher_up in higher_ups.groups.keys():
+            if higher_up not in tree:
+                tree[higher_up] = []
+                for group in higher_ups.get_group(higher_up)['GPBD_NAME'].values:
+                    tree[higher_up].append(group)
+                    where_is[group] = tree[higher_up]
+        # initially, for an owner tree, anchor can be a user (like IBMUSER) or a group
+        # now we gotta condense it, so only IBMUSER and other group owning users are at top level
+        # for group tree, we should end up with SYS1, and a list of groups
+        deletes = []
+        for anchor in tree:
+            if anchor in where_is:
+                supgrpMembers = where_is[anchor]
+                ix = supgrpMembers.index(anchor)
+                supgrpMembers[ix] = {anchor: tree[anchor]}
+                deletes.append(anchor)
+        for anchor in deletes:
+            tree.pop(anchor)
         return tree
 
     def ownertree(self):
@@ -581,15 +681,15 @@ class RACF:
         create dict with the user IDs that own groups as key, and a list of their owned groups as values.
         if a group in this list owns group, the list is replaced by a dict.
         '''
-        return self.tree(self._ownertree,"GPBD_OWNER_ID")
+        return self._ownertree if self._ownertree else self.tree("GPBD_OWNER_ID")
 
     def grouptree(self):
         ''' 
         create dict starting with SYS1, and a list of groups owned by SYS1 as values.
         if a group in this list owns group, the list is replaced by a dict.
-        because SYS1's superior group is blank/missing, we return the first group that is owned by "".
+        because SYS1s superior group is blank/missing, we return the first group that is owned by "".
         '''
-        return self.tree(self._grouptree,"GPBD_SUPGRP_ID")[""][0]
+        return self._grouptree if self._grouptree else self.tree("GPBD_SUPGRP_ID")[""][0]
 
     def getdatasetrisk(self, profile=''):
         '''This will produce a dict as follows:
@@ -612,7 +712,7 @@ class RACF:
         peraccess = dsacc.get_group(profile).groupby('DSACC_ACCESS')
         for access in ['NONE','EXECUTE','READ','UPDATE','CONTROL','ALTER']:
             accesslist[access] = []
-            accessmanagers = []
+            accessmanagers[access] = []
             if access in peraccess.groups.keys():
                 a = peraccess.get_group(access)['DSACC_AUTH_ID'].values
                 for id in a:
@@ -625,36 +725,35 @@ class RACF:
                                 accesslist[access].append(user)
                                 # But suppose this user is group_special here?
                                 if grp_special=='YES':
-                                    accessmanagers.append(user)
+                                    accessmanagers[access].append(user)
                             # And wait a minute... this groups owner, can also add people to the group?
                             [gowner,gsupgroup] = self.group(id)[['GPBD_OWNER_ID','GPBD_SUPGRP_ID']].values[0]
                             if len(self.user(gowner)) == 1:
-                                accessmanagers.append(gowner)
+                                accessmanagers[access].append(gowner)
                             else:
                                 # group special propages up
-                                while gowner==gsupgrp:
-                                    gg = self.connectData.loc[self.connectData.USCON_GRP_ID==gowner]
-                                    for user,grp_special in gg[['USCON_NAME','USCON_GRP_SPECIAL']].values:
+                                while gowner==gsupgroup:
+                                    g = self.connectData.loc[self.connectData.USCON_GRP_ID==gowner]
+                                    for user,grp_special in g[['USCON_NAME','USCON_GRP_SPECIAL']].values:
                                         if grp_special=='YES':
-                                            accessmanagers.append(user)
+                                            accessmanagers[access].append(user)
                                     [gowner,gsupgroup] = self.group(gowner)[['GPBD_OWNER_ID','GPBD_SUPGRP_ID']].values[0]
                             # connect authority CONNECT/JOIN allows modification of member list
                             g = self.connects.loc[self.connects.GPMEM_NAME==id]
                             for user,grp_auth in g[['GPMEM_MEMBER_ID','GPMEM_AUTH']].values:
                                 if grp_auth in ('CONNECT','JOIN'):
-                                    accessmanagers.append(user)
+                                    accessmanagers[access].append(user)
                 # clean up doubles...
-            accessmanagers = list(set(accessmanagers))
-            accesslist[access] = list(set(accesslist[access]))
+                accesslist[access] = list(set(accesslist[access]))
+                accessmanagers[access] = list(set(accessmanagers[access]))
 
-        y = {
+        return {
             'owner': owner,
-            'accessmanagers': accessmanagers,
             'uacc': d['DSBD_UACC'].values[0],
+            'accessmanagers': accessmanagers,
             'permits': accesslist
         }
 
-        return y
 
 class IRRDBU(RACF):
     pass

--- a/src/pyracf/__init__.py
+++ b/src/pyracf/__init__.py
@@ -328,7 +328,9 @@ class RACF:
                     keys = [rinfo["name"]+"_CLASS_NAME",rinfo["name"]+"_NAME"]
                 else:
                     keys = rinfo["name"]+"_NAME"
+                none_mask = None if type(keys)==str else [None,None,None][0:len(keys)]
                 getattr(self,rinfo['df']).set_index(keys,drop=False,inplace=True)
+                getattr(self,rinfo['df']).rename_axis(none_mask,inplace=True)  # prevent ambigous index / column names 
         
         
         

--- a/src/pyracf/getOffsets.py
+++ b/src/pyracf/getOffsets.py
@@ -43,7 +43,7 @@ for url in urls:
         })
       model.update({
         rdesc: {
-          "record-type": rtype,
+          "record-type": rtype.upper(),  # 05k0 is in fact 05K0
           "ref-url": url,
           "offsets": rfields
       }})

--- a/src/pyracf/offsets.json
+++ b/src/pyracf/offsets.json
@@ -6633,7 +6633,7 @@
         ]
     },
     "general-resource-idtparms-definition-record": {
-        "record-type": "05k0",
+        "record-type": "05K0",
         "ref-url": "https://www.ibm.com/docs/en/SSLTBW_3.1.0/com.ibm.zos.v3r1.icha300/grr.htm",
         "offsets": [
             {


### PR DESCRIPTION
I added code that parses all record types from unload into dataframes.  Currently no reporting for these new df.
Added relevant index fields for all dataframes to allow for increased analysis speed and flexibility, for example
IBMuser = msys._users.loc["IBMUSER"]

The original field names are still available to support 
IBMuser = msys._users.loc[msys._users["USBD_NAME"]=="IBMUSER"]

Please try out with larger database.