### PR TITLE
.acl( ) method

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To get started with PyRACF, install it using `pip install pyracf` or explore the
 
 ## Updates
 
-### 0.7.0 (General instead of Generic)
+### 0.7.1 (General instead of Generic)
 - fixed: Generic should be General resource profiles, variables and methods renamed
 - Mapping between IRRDBU00 record types and variables centralized in a dict
 - global constants related to record types removed

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="pyracf",
-    version="0.7.0",
+    version="0.7.1",
     author="Wizard of z/OS",
     author_email="wizard@zdevops.com",
     description="Parsing IRRDBU00 unloads in panda dataframes.",

--- a/src/pyracf/__init__.py
+++ b/src/pyracf/__init__.py
@@ -884,9 +884,8 @@ class RACF:
             rules= yaml.safe_load(rules)
 
         def listMe(item):
-            ''' make list in parameters optional when there is only 1 item
-            also, to facilitate yaml input, "DSAC, DSCACC" is interpreter as list of str  '''
-            return item if type(item)==list else item.replace(',',' ').split() if type(item)==str else [item]
+            ''' make list in parameters optional when there is only 1 item '''
+            return item if type(item)==list else [item]
         
         brokenSum = pd.DataFrame(columns=['CLASS','PROFILE','FIELD_NAME','EXPECT','VALUE'])
         for (tbNames,*tbCriteria) in rules:

--- a/src/pyracf/__init__.py
+++ b/src/pyracf/__init__.py
@@ -265,7 +265,7 @@ class RACF:
         # make completed line always show 100% :)
         print(f'{datetime.now().strftime("%y-%m-%d %H:%M:%S")} - progress: {63*"▉"} ({100:.2f}%)'.center(80))
         for r in recordtypes:
-            print(f'{datetime.now().strftime("%y-%m-%d %H:%M:%S")} - recordtype {r} -> {self._records[r]["parsed"]} records parsed')
+            print(f'{datetime.now().strftime("%y-%m-%d %H:%M:%S")} - recordtype {r} -> {self.parsed(self._recordtype_info[r]["name"])} records parsed')
         print(f'{datetime.now().strftime("%y-%m-%d %H:%M:%S")} - total parse time: {(self._stoptime - self._starttime).total_seconds()} seconds')
         if save_pickles:
             self.save_pickles(path=save_pickles,prefix=prefix)

--- a/src/pyracf/__init__.py
+++ b/src/pyracf/__init__.py
@@ -869,6 +869,95 @@ class RACF:
         return acl.sort_values(by=sortBy[sort])[tbProfileKeys+returnFields].reset_index(drop=True)
 
     
+    def verify(self, rules=None, domains=None):
+        ''' verify fields in profiles against the expected value, issues are returned in a df
+        rules can be passed as a list of tuples, or dict via parameter, or as function result from external module.
+        '''
+        
+        from .profileFieldRules import _domains, _rules
+        if not rules:
+            rules = _rules(self)
+        if not domains:
+            domains = _domains(self,pd)  # needs pandas
+
+        def listMe(item):
+            ''' make list in parameters optional when there is only 1 item '''
+            return item if type(item)==list else [item]
+        
+        brokenSum = pd.DataFrame(columns=['CLASS','PROFILE','FIELD_NAME','EXPECT','VALUE'])
+        for (tbNames,tbCriteria) in rules:
+            for tbName in listMe(tbNames):
+                if self.parsed(tbName)==0:
+                    continue
+                tbDF = getattr(self,RACF._recordname_df[tbName])
+                if tbDF.empty:
+                    continue
+                tbEntity = tbName[0:2]
+                tbClassName = {'DS':'dataset', 'GP':'group', 'GR':'general', 'US':'user'}[tbEntity]
+                for tbCrit in listMe(tbCriteria):
+                    locs = True
+                    matchPattern = None
+                    if 'class' in tbCrit:
+                        if tbEntity!='GR':
+                            print('only for GR')
+                        classPattern = ''
+                        for cl in listMe(tbCrit['class']):
+                            classPattern += RACF.generic2regex(cl) + "|"
+                        locs &= tbDF.index.get_level_values(0).str.match(classPattern[:-1])
+                    if 'notclass' in tbCrit:
+                        if tbEntity=='GR':
+                            classPattern = ''
+                            for cl in listMe(tbCrit['notclass']):
+                                classPattern += RACF.generic2regex(cl) + "|"
+                            locs &= ~ tbDF.index.get_level_values(0).str.match(classPattern[:-1])
+                    if 'profile' in tbCrit:
+                        ixLevel = 1 if tbEntity=='GR' else 0
+                        locs &= tbDF.index.get_level_values(ixLevel).str.match(RACF.generic2regex(tbCrit['profile']))
+                    if 'notprofile' in tbCrit:
+                        ixLevel = 1 if tbEntity=='GR' else 0
+                        locs &= ~ tbDF.index.get_level_values(ixLevel).str.match(RACF.generic2regex(tbCrit['notprofile']))
+                    if 'match' in tbCrit:
+                        matchPattern = tbCrit['match'].replace('.','\.').replace('*','\*')\
+                                                      .replace('(','(?P<').replace(')','>[0-9A-Z@#$&]*)')
+                        matched = tbDF[tbName+'_NAME'].str.extract(matchPattern)
+                    for fldCrit in listMe(tbCrit['fields']):
+                        fldName = fldCrit['name'] if matchPattern else tbName+'_'+fldCrit['name']
+                        fldExpect = fldCrit['expect'] if 'expect' in fldCrit else None
+                        if matchPattern:
+                            for fn in matched.columns:
+                                if fn==fldName:
+                                    if fldExpect:
+                                        locs &= matched[fn].gt('') & - matched[fn].isin(domains[fldExpect])
+                                    if 'or' in fldCrit:
+                                        locs &= ~ matched[fn].isin(listMe(fldCrit['or']))
+                        else:
+                            if fldExpect:
+                                locs &= tbDF[fldName].gt('') & - tbDF[fldName].isin(domains[fldExpect])
+                            if 'or' in fldCrit:
+                                locs &= ~ tbDF[fldName].isin(listMe(fldCrit['or']))
+                        if any(locs):
+                            broken = tbDF.loc[locs].copy()
+                            broken['CLASS'] = broken[tbName+'_CLASS_NAME'] if tbEntity=='GR' else tbClassName
+                            broken['PROFILE'] = broken[tbName+'_NAME']
+                            broken['FIELD_NAME'] = fldName
+                            broken['EXPECT'] = fldExpect
+                            broken['VALUE'] = matched[fldName] if matchPattern else broken[fldName]
+                            brokenSum = pd.concat([brokenSum,
+                                                    broken[['CLASS','PROFILE','FIELD_NAME','EXPECT','VALUE']]],
+                                                   sort=False, ignore_index=True)
+        return brokenSum        
+    
+
+    @property
+    def neworphans(self):
+        return self.verify(
+            rules = [
+                (['DSACC','DSCACC','GRACC','GRCACC'],
+                 {'fields': {'name':'AUTH_ID', 'expect':'ACLID'}})
+            ]
+        )
+
+
     @property
     def orphans(self):
         

--- a/src/pyracf/profileFieldRules.py
+++ b/src/pyracf/profileFieldRules.py
@@ -29,29 +29,28 @@ def _rules(self, format='yaml'):
 
     if format=='yaml':
 
-        # YAML definition, should generate a list of lists, each table entry is identified by - -
-        # the values with commas in the table ID line is a string for YAML, but interpreted as a list in the verify() function
+        # YAML definition, should generate a list of lists, each table section is identified by - -
         # list of lists, each with (list of) table ids, and one or more conditions.
         # each condition allows class, -class, profile, -profile, match and field.
         # class, -class, profile and -profile are (currently) generic patterns, and select or skip profile/segment/entries.
         # match extracts fields from the profile key, the name should be used in subsequent fields rules.
-        # field test if the value occurs in one of the domains, or a (list of) literal(s).
+        # field tests if the value occurs in one of the domains, or a (list of) literal(s).
 
         return '''
 
-- - DSACC, DSCACC, DSMEM, GRACC, GRCACC
+- - [DSACC, DSCACC, DSMEM, GRACC, GRCACC]
   - field:
       name: AUTH_ID
       expect: ACLID
-      comment: orphan permits
+    comment: orphan permits
 
 - - DSDFP
   - field:
     - name: RESOWNER_ID
       expect: ID
-      comment: DFP resower must be user or group
+    comment: DFP resower must be user or group
 
-- - DSBD, GRBD
+- - [DSBD, GRBD]
   - field:
     - name: NOTIFY_ID
       expect: USER
@@ -67,79 +66,76 @@ def _rules(self, format='yaml'):
     field:
       name: id
       expect: USER
-      comment: DIGTRING is associated with a user ID
+    comment: DIGTRING should be associated with a user ID
   - class: JESSPOOL
     match: '&RACLNDE.(id).'
     field:
       name: id
       expect: USERQUAL
-      comment: JESSPOOL is associated with a user ID
+    comment: JESSPOOL should be associated with a user ID
   - class: SURROGAT
     match: (id).SUBMIT
     field:
       name: id
       expect: USERQUAL
-      comment: surrogate profiles must refer to user ID or RACFVARS
   - class: SURROGAT
     match: BPX.(type).(user)
     field:
       name: user
       expect: USERQUAL
-      comment: surrogate profiles must refer to user ID or RACFVARS
+    comment: surrogate profiles must refer to user ID or RACFVARS
 
-- - GRACC, GRCACC
-  - class: CDT, CFIELD, NODES, RACFVARS, SECDATA, STARTED, UNIXMAP
+- - [GRACC, GRCACC]
+  - class: [CDT, CFIELD, NODES, RACFVARS, SECDATA, STARTED, UNIXMAP]
     field:
     - name: AUTH_ID
       expect: DELETE
-      comment: class does not support PERMIT
+    comment: class does not support PERMIT
 
-- - GRFLTR, GRDMAP
+- - [GRFLTR, GRDMAP]
   - field:
       name: USER
       expect: USER
-      comment: orphan users in filters and maps
+    comment: orphan users in filters and maps
 
 - - GRST
   - field:
     - name: USER_ID
       expect: USER
       or: =NODATA
-      comment: orphans in STARTED profiles
     - name: GROUP_ID
       expect: GROUP
       or: =NODATA
-      comment: orphans in STARTED profiles
+    comment: orphans in STARTED profiles
 
 - - USBD
   - field:
     - name: DEFGRP_ID
       expect: GROUP
-      comment: users should have valid default group and owner
     - name: OWNER_ID
       expect: ID
-      comment: users should have valid default group and owner
+    comment: users should have valid default group and owner
 
-- - DSCAT, GRCAT, GRMEM, USCAT
-  - -class: SECDATA, SECLABEL
+- - [DSCAT, GRCAT, GRMEM, USCAT]
+  - -class: [SECDATA, SECLABEL]
     field:
     - name: CATEGORY
       expect: CATEGORY
-      comment: valid CATEGORY (except in SECDATA and SECLABEL profiles where the internal values are used)
+    comment: valid CATEGORY (except in SECDATA and SECLABEL profiles where the internal values are used)
 
-- - DSBD, GRBD, GRMEM, USBD
-  - -class: SECDATA, SECLABEL
+- - [DSBD, GRBD, GRMEM, USBD]
+  - -class: [SECDATA, SECLABEL]
     field:
     - name: SECLEVEL
       expect: SECLEVEL
       or: '000'
-      comment: valid CATEGORY, SECLEVEL and SECLABEL (except in SECDATA and SECLABEL profiles where the internal values are used)
+    comment: valid SECLEVEL (except in SECDATA and SECLABEL profiles where the internal values are used)
 
-- - DSBD, GRBD, USBD, USTSO
+- - [DSBD, GRBD, USBD, USTSO]
   - field:
     - name: SECLABEL
       expect: SECLABEL
-      comment: valid CATEGORY, SECLEVEL and SECLABEL
+    comment: valid SECLABEL
 
 '''
 

--- a/src/pyracf/profileFieldRules.py
+++ b/src/pyracf/profileFieldRules.py
@@ -24,78 +24,78 @@ def _domains(self,pd):
     domains.update({'USERQUAL':self.users.index.union(domains['RACFVARS'])})
     return domains
     
-# list of tuples, each with (list of) table ids and conditions.
-# each condition allows fields, class, notclass, profile, notprofile and match.
-# class, notclass, profile and notprofile are (cuurently) generic patterns.
+# list of tuples, each with (list of) table ids, and one or more conditions.
+# each condition allows class, -class, profile, -profile, match and field.
+# class, -class, profile and -profile are (currently) generic patterns.
 # match extracts fields from the profile key, the name should be used in subsequent fields rules.
-# fields test if the value occurs in one of the domains, or a (list of) literal(s).
+# field test if the value occurs in one of the domains, or a (list of) literal(s).
 
 def _rules(self):
     rules = [
         # orphan permits
         (['DSACC','DSCACC','DSMEM','GRACC','GRCACC'],
-         {'fields':[
+         {'field':[
             {'name':'AUTH_ID', 'expect':'ACLID'},
             ]
          }
         ),
         # DFP resower must be user of group
         (['DSDFP'],
-         {'fields':
+         {'field':
             {'name':'RESOWNER_ID', 'expect':'ID'},
          }
         ),
         # notify on dataset and resource profiles must be user, owner must be user or group
         (['DSBD','GRBD'],
-         {'fields':[
+         {'field':[
             {'name':'NOTIFY_ID', 'expect':'USER'},
             {'name':'OWNER_ID', 'expect':'ID'}
             ]
          }
         ),
         # general resource profile key qualifiers
-        ('GRBD',[
+        ('GRBD',
          # DIGTRING is associated with a user ID
          {'class':'DIGTRING',
           'match':'(id).',
-          'fields':
+          'field':
               {'name':'id', 'expect':'USER'}        
          },
          # JESSPOOL is associated with a user ID
          {'class':'JESSPOOL',
           'match':'&RACLNDE.(id).',
-          'fields':
+          'field':
               {'name':'id', 'expect':'USERQUAL'}        
          },
          # surrogate profiles must refer to user ID or RACFVARS
          {'class':'SURROGAT',
           'match':'(id).SUBMIT',
-          'fields':
+          'field':
               {'name':'id', 'expect':'USERQUAL'}        
          },
          {'class':'SURROGAT',
           'match':'BPX.(type).(user)',
-          'fields':
+          'field':
               {'name':'user', 'expect':'USERQUAL'}        
-         }]
+         }
         ),
         # classes that do not support PERMIT
         (['GRACC','GRCACC'],
          {'class':['CDT','CFIELD','RACFVARS','SECDATA','STARTED','UNIXMAP'],
-          'fields':[
+          'field':[
             {'name':'AUTH_ID', 'expect':'DELETE'},
             ]
          }
         ),
         # orphan users in filters and maps
         (['GRFLTR','GRDMAP'],
-         {'fields':
+         {'field':
             {'name':'USER', 'expect':'USER'}
          }
         ),
         # orphans in STARTED profiles
         ('GRST',
-         {'fields':[
+         {'field':[
             {'name':'USER_ID', 'expect':'USER', 'or':'=NODATA'},
             {'name':'GROUP_ID', 'expect':'GROUP', 'or':'=NODATA'}
             ]
@@ -103,7 +103,7 @@ def _rules(self):
         ),
         # users should have valid default group and owner
         ('USBD',
-         {'fields':[
+         {'field':[
             {'name':'DEFGRP_ID', 'expect':'GROUP'},
             {'name':'OWNER_ID', 'expect':'ID'}
             ]
@@ -111,21 +111,21 @@ def _rules(self):
         ),
         # valid CATEGORY, SECLEVEL and SECLABEL
         (['DSCAT','GRCAT','GRMEM','USCAT'],
-         {'notclass':['SECDATA','SECLABEL'],
-          'fields':[
+         {'-class':['SECDATA','SECLABEL'],
+          'field':[
             {'name':'CATEGORY', 'expect':'CATEGORY'},
             ]
          }
         ),
         (['DSBD','GRBD','GRMEM','USBD'],
-         {'notclass':['SECDATA','SECLABEL'],
-          'fields':[
+         {'-class':['SECDATA','SECLABEL'],
+          'field':[
             {'name':'SECLEVEL', 'expect':'SECLEVEL', 'or':'000'},
             ]
          }
         ),
         (['DSBD','GRBD','USBD','USTSO'],
-         {'fields':[
+         {'field':[
             {'name':'SECLABEL', 'expect':'SECLABEL'},
             ]
          }

--- a/src/pyracf/profileFieldRules.py
+++ b/src/pyracf/profileFieldRules.py
@@ -17,10 +17,10 @@ def _domains(self,pd):
     }
     domains.update({'ID':self.users.index.union(self.groups.index)})
     domains.update({'ACLID':domains['SPECIAL'].union(domains['ID'])})
-    domains.update({'RACFVARS':self.generals.loc['RACFVARS'].index})
+    domains.update({'RACFVARS':self.generals.gfilter('RACFVARS').index.get_level_values(1)})
     domains.update({'CATEGORY':self.generalMembers['GRMEM_MEMBER'].gfilter('SECDATA','CATEGORY').values})
     domains.update({'SECLEVEL':self.generalMembers['GRMEM_MEMBER'].gfilter('SECDATA','SECLEVEL').values})
-    domains.update({'SECLABEL':self.generals.loc['SECLABEL'].index})
+    domains.update({'SECLABEL':self.generals.gfilter('SECLABEL').index.get_level_values(1)})
     domains.update({'USERQUAL':self.users.index.union(domains['RACFVARS'])})
     return domains
     
@@ -55,6 +55,18 @@ def _rules(self):
         ),
         # general resource profile key qualifiers
         ('GRBD',[
+         # DIGTRING is associated with a user ID
+         {'class':'DIGTRING',
+          'match':'(id).',
+          'fields':
+              {'name':'id', 'expect':'USER'}        
+         },
+         # JESSPOOL is associated with a user ID
+         {'class':'JESSPOOL',
+          'match':'&RACLNDE.(id).',
+          'fields':
+              {'name':'id', 'expect':'USERQUAL'}        
+         },
          # surrogate profiles must refer to user ID or RACFVARS
          {'class':'SURROGAT',
           'match':'(id).SUBMIT',

--- a/src/pyracf/profileFieldRules.py
+++ b/src/pyracf/profileFieldRules.py
@@ -1,0 +1,122 @@
+''' rules for the pyracf.verify() service.
+This file is imported from __init__.py and used in verify()
+
+domains provides the sets of values that can be expected in profile fields and qualifiers.
+rules specifies where these domain values should be expected.
+'''
+
+# dict returns a list, array or Series that will be used in .loc[field.isin( )] to verify valid values in profile fields.
+# keys of the dict are only those referenced in the corresp. rules.
+
+def _domains(self,pd):
+    domains = {
+        'SPECIAL':pd.Index(['*','&RACUID','&RACGRP'],name='_NAME'),
+        'USER':self.users.index,
+        'GROUP':self.groups.index,
+        'DELETE':['']
+    }
+    domains.update({'ID':self.users.index.union(self.groups.index)})
+    domains.update({'ACLID':domains['SPECIAL'].union(domains['ID'])})
+    domains.update({'RACFVARS':self.generals.loc['RACFVARS'].index})
+    domains.update({'CATEGORY':self.generalMembers['GRMEM_MEMBER'].gfilter('SECDATA','CATEGORY').values})
+    domains.update({'SECLEVEL':self.generalMembers['GRMEM_MEMBER'].gfilter('SECDATA','SECLEVEL').values})
+    domains.update({'SECLABEL':self.generals.loc['SECLABEL'].index})
+    domains.update({'USERQUAL':self.users.index.union(domains['RACFVARS'])})
+    return domains
+    
+# list of tuples, each with (list of) table ids and conditions.
+# each condition allows fields, class, notclass, profile, notprofile and match.
+# class, notclass, profile and notprofile are (cuurently) generic patterns.
+# match extracts fields from the profile key, the name should be used in subsequent fields rules.
+# fields test if the value occurs in one of the domains, or a (list of) literal(s).
+
+def _rules(self):
+    rules = [
+        # orphan permits
+        (['DSACC','DSCACC','DSMEM','GRACC','GRCACC'],
+         {'fields':[
+            {'name':'AUTH_ID', 'expect':'ACLID'},
+            ]
+         }
+        ),
+        # DFP resower must be user of group
+        (['DSDFP'],
+         {'fields':
+            {'name':'RESOWNER_ID', 'expect':'ID'},
+         }
+        ),
+        # notify on dataset and resource profiles must be user, owner must be user or group
+        (['DSBD','GRBD'],
+         {'fields':[
+            {'name':'NOTIFY_ID', 'expect':'USER'},
+            {'name':'OWNER_ID', 'expect':'ID'}
+            ]
+         }
+        ),
+        # general resource profile key qualifiers
+        ('GRBD',[
+         # surrogate profiles must refer to user ID or RACFVARS
+         {'class':'SURROGAT',
+          'match':'(id).SUBMIT',
+          'fields':
+              {'name':'id', 'expect':'USERQUAL'}        
+         },
+         {'class':'SURROGAT',
+          'match':'BPX.(type).(user)',
+          'fields':
+              {'name':'user', 'expect':'USERQUAL'}        
+         }]
+        ),
+        # classes that do not support PERMIT
+        (['GRACC','GRCACC'],
+         {'class':['CDT','CFIELD','RACFVARS','SECDATA','STARTED','UNIXMAP'],
+          'fields':[
+            {'name':'AUTH_ID', 'expect':'DELETE'},
+            ]
+         }
+        ),
+        # orphan users in filters and maps
+        (['GRFLTR','GRDMAP'],
+         {'fields':
+            {'name':'USER', 'expect':'USER'}
+         }
+        ),
+        # orphans in STARTED profiles
+        ('GRST',
+         {'fields':[
+            {'name':'USER_ID', 'expect':'USER', 'or':'=NODATA'},
+            {'name':'GROUP_ID', 'expect':'GROUP', 'or':'=NODATA'}
+            ]
+         }
+        ),
+        # users should have valid default group and owner
+        ('USBD',
+         {'fields':[
+            {'name':'DEFGRP_ID', 'expect':'GROUP'},
+            {'name':'OWNER_ID', 'expect':'ID'}
+            ]
+         }
+        ),
+        # valid CATEGORY, SECLEVEL and SECLABEL
+        (['DSCAT','GRCAT','GRMEM','USCAT'],
+         {'notclass':['SECDATA','SECLABEL'],
+          'fields':[
+            {'name':'CATEGORY', 'expect':'CATEGORY'},
+            ]
+         }
+        ),
+        (['DSBD','GRBD','GRMEM','USBD'],
+         {'notclass':['SECDATA','SECLABEL'],
+          'fields':[
+            {'name':'SECLEVEL', 'expect':'SECLEVEL', 'or':'000'},
+            ]
+         }
+        ),
+        (['DSBD','GRBD','USBD','USTSO'],
+         {'fields':[
+            {'name':'SECLABEL', 'expect':'SECLABEL'},
+            ]
+         }
+        )
+    ]
+    return rules

--- a/src/pyracf/profileFieldRules.py
+++ b/src/pyracf/profileFieldRules.py
@@ -23,112 +23,231 @@ def _domains(self,pd):
     domains.update({'SECLABEL':self.generals.gfilter('SECLABEL').index.get_level_values(1)})
     domains.update({'USERQUAL':self.users.index.union(domains['RACFVARS'])})
     return domains
-    
-# list of tuples, each with (list of) table ids, and one or more conditions.
-# each condition allows class, -class, profile, -profile, match and field.
-# class, -class, profile and -profile are (currently) generic patterns.
-# match extracts fields from the profile key, the name should be used in subsequent fields rules.
-# field test if the value occurs in one of the domains, or a (list of) literal(s).
 
-def _rules(self):
-    rules = [
-        # orphan permits
-        (['DSACC','DSCACC','DSMEM','GRACC','GRCACC'],
-         {'field':[
-            {'name':'AUTH_ID', 'expect':'ACLID'},
-            ]
-         }
-        ),
-        # DFP resower must be user of group
-        (['DSDFP'],
-         {'field':
-            {'name':'RESOWNER_ID', 'expect':'ID'},
-         }
-        ),
-        # notify on dataset and resource profiles must be user, owner must be user or group
-        (['DSBD','GRBD'],
-         {'field':[
-            {'name':'NOTIFY_ID', 'expect':'USER'},
-            {'name':'OWNER_ID', 'expect':'ID'}
-            ]
-         }
-        ),
-        # general resource profile key qualifiers
-        ('GRBD',
-         # DIGTRING is associated with a user ID
-         {'class':'DIGTRING',
-          'match':'(id).',
-          'field':
-              {'name':'id', 'expect':'USER'}        
-         },
-         # JESSPOOL is associated with a user ID
-         {'class':'JESSPOOL',
-          'match':'&RACLNDE.(id).',
-          'field':
-              {'name':'id', 'expect':'USERQUAL'}        
-         },
-         # surrogate profiles must refer to user ID or RACFVARS
-         {'class':'SURROGAT',
-          'match':'(id).SUBMIT',
-          'field':
-              {'name':'id', 'expect':'USERQUAL'}        
-         },
-         {'class':'SURROGAT',
-          'match':'BPX.(type).(user)',
-          'field':
-              {'name':'user', 'expect':'USERQUAL'}        
-         }
-        ),
-        # classes that do not support PERMIT
-        (['GRACC','GRCACC'],
-         {'class':['CDT','CFIELD','RACFVARS','SECDATA','STARTED','UNIXMAP'],
-          'field':[
-            {'name':'AUTH_ID', 'expect':'DELETE'},
-            ]
-         }
-        ),
-        # orphan users in filters and maps
-        (['GRFLTR','GRDMAP'],
-         {'field':
-            {'name':'USER', 'expect':'USER'}
-         }
-        ),
-        # orphans in STARTED profiles
-        ('GRST',
-         {'field':[
-            {'name':'USER_ID', 'expect':'USER', 'or':'=NODATA'},
-            {'name':'GROUP_ID', 'expect':'GROUP', 'or':'=NODATA'}
-            ]
-         }
-        ),
-        # users should have valid default group and owner
-        ('USBD',
-         {'field':[
-            {'name':'DEFGRP_ID', 'expect':'GROUP'},
-            {'name':'OWNER_ID', 'expect':'ID'}
-            ]
-         }
-        ),
-        # valid CATEGORY, SECLEVEL and SECLABEL
-        (['DSCAT','GRCAT','GRMEM','USCAT'],
-         {'-class':['SECDATA','SECLABEL'],
-          'field':[
-            {'name':'CATEGORY', 'expect':'CATEGORY'},
-            ]
-         }
-        ),
-        (['DSBD','GRBD','GRMEM','USBD'],
-         {'-class':['SECDATA','SECLABEL'],
-          'field':[
-            {'name':'SECLEVEL', 'expect':'SECLEVEL', 'or':'000'},
-            ]
-         }
-        ),
-        (['DSBD','GRBD','USBD','USTSO'],
-         {'field':[
-            {'name':'SECLABEL', 'expect':'SECLABEL'},
-            ]
-         }
-        )
-    ]
-    return rules
+
+def _rules(self, format='yaml'):
+
+    if format=='yaml':
+
+        # YAML definition, should generate a list of lists, each table entry is identified by - -
+        # the values with commas in the table ID line is a string for YAML, but interpreted as a list in the verify() function
+        # list of lists, each with (list of) table ids, and one or more conditions.
+        # each condition allows class, -class, profile, -profile, match and field.
+        # class, -class, profile and -profile are (currently) generic patterns, and select or skip profile/segment/entries.
+        # match extracts fields from the profile key, the name should be used in subsequent fields rules.
+        # field test if the value occurs in one of the domains, or a (list of) literal(s).
+
+        return '''
+
+- - DSACC, DSCACC, DSMEM, GRACC, GRCACC
+  - field:
+      name: AUTH_ID
+      expect: ACLID
+      comment: orphan permits
+
+- - DSDFP
+  - field:
+    - name: RESOWNER_ID
+      expect: ID
+      comment: DFP resower must be user or group
+
+- - DSBD, GRBD
+  - field:
+    - name: NOTIFY_ID
+      expect: USER
+      comment: notify on dataset and resource profiles must be user
+    - name: OWNER_ID
+      expect: ID
+      comment: owner must be user or group
+
+# general resource profile key qualifiers
+- - GRBD
+  - class: DIGTRING
+    match: (id).
+    field:
+      name: id
+      expect: USER
+      comment: DIGTRING is associated with a user ID
+  - class: JESSPOOL
+    match: '&RACLNDE.(id).'
+    field:
+      name: id
+      expect: USERQUAL
+      comment: JESSPOOL is associated with a user ID
+  - class: SURROGAT
+    match: (id).SUBMIT
+    field:
+      name: id
+      expect: USERQUAL
+      comment: surrogate profiles must refer to user ID or RACFVARS
+  - class: SURROGAT
+    match: BPX.(type).(user)
+    field:
+      name: user
+      expect: USERQUAL
+      comment: surrogate profiles must refer to user ID or RACFVARS
+
+- - GRACC, GRCACC
+  - class: CDT, CFIELD, NODES, RACFVARS, SECDATA, STARTED, UNIXMAP
+    field:
+    - name: AUTH_ID
+      expect: DELETE
+      comment: class does not support PERMIT
+
+- - GRFLTR, GRDMAP
+  - field:
+      name: USER
+      expect: USER
+      comment: orphan users in filters and maps
+
+- - GRST
+  - field:
+    - name: USER_ID
+      expect: USER
+      or: =NODATA
+      comment: orphans in STARTED profiles
+    - name: GROUP_ID
+      expect: GROUP
+      or: =NODATA
+      comment: orphans in STARTED profiles
+
+- - USBD
+  - field:
+    - name: DEFGRP_ID
+      expect: GROUP
+      comment: users should have valid default group and owner
+    - name: OWNER_ID
+      expect: ID
+      comment: users should have valid default group and owner
+
+- - DSCAT, GRCAT, GRMEM, USCAT
+  - -class: SECDATA, SECLABEL
+    field:
+    - name: CATEGORY
+      expect: CATEGORY
+      comment: valid CATEGORY (except in SECDATA and SECLABEL profiles where the internal values are used)
+
+- - DSBD, GRBD, GRMEM, USBD
+  - -class: SECDATA, SECLABEL
+    field:
+    - name: SECLEVEL
+      expect: SECLEVEL
+      or: '000'
+      comment: valid CATEGORY, SECLEVEL and SECLABEL (except in SECDATA and SECLABEL profiles where the internal values are used)
+
+- - DSBD, GRBD, USBD, USTSO
+  - field:
+    - name: SECLABEL
+      expect: SECLABEL
+      comment: valid CATEGORY, SECLEVEL and SECLABEL
+
+'''
+
+    else:
+        # list of tuples, each with (list of) table ids, and one or more conditions.
+        # each condition allows class, -class, profile, -profile, match and field.
+        # class, -class, profile and -profile are (currently) generic patterns, and select or skip profile/segment/entries.
+        # match extracts fields from the profile key, the name should be used in subsequent fields rules.
+        # field test if the value occurs in one of the domains, or a (list of) literal(s).
+
+        return [
+            # orphan permits
+            (['DSACC','DSCACC','DSMEM','GRACC','GRCACC'],
+             {'field':
+                {'name':'AUTH_ID', 'expect':'ACLID'},
+             }
+            ),
+            # DFP resower must be user or group
+            (['DSDFP'],
+             {'field':[
+                {'name':'RESOWNER_ID', 'expect':'ID'},
+                ]
+             }
+            ),
+            # notify on dataset and resource profiles must be user, owner must be user or group
+            (['DSBD','GRBD'],
+             {'field':[
+                {'name':'NOTIFY_ID', 'expect':'USER'},
+                {'name':'OWNER_ID', 'expect':'ID'}
+                ]
+             }
+            ),
+            # general resource profile key qualifiers
+            ('GRBD',
+             # DIGTRING is associated with a user ID
+             {'class':'DIGTRING',
+              'match':'(id).',
+              'field':
+                  {'name':'id', 'expect':'USER'}
+             },
+             # JESSPOOL is associated with a user ID
+             {'class':'JESSPOOL',
+              'match':'&RACLNDE.(id).',
+              'field':
+                  {'name':'id', 'expect':'USERQUAL'}
+             },
+             # surrogate profiles must refer to user ID or RACFVARS
+             {'class':'SURROGAT',
+              'match':'(id).SUBMIT',
+              'field':
+                  {'name':'id', 'expect':'USERQUAL'}
+             },
+             {'class':'SURROGAT',
+              'match':'BPX.(type).(user)',
+              'field':
+                  {'name':'user', 'expect':'USERQUAL'}
+             }
+            ),
+            # classes that do not support PERMIT
+            (['GRACC','GRCACC'],
+             {'class':['CDT','CFIELD','NODES','RACFVARS','SECDATA','STARTED','UNIXMAP'],
+              'field':[
+                {'name':'AUTH_ID', 'expect':'DELETE'},
+                ]
+             }
+            ),
+            # orphan users in filters and maps
+            (['GRFLTR','GRDMAP'],
+             {'field':
+                {'name':'USER', 'expect':'USER'}
+             }
+            ),
+            # orphans in STARTED profiles
+            ('GRST',
+             {'field':[
+                {'name':'USER_ID', 'expect':'USER', 'or':'=NODATA'},
+                {'name':'GROUP_ID', 'expect':'GROUP', 'or':'=NODATA'}
+                ]
+             }
+            ),
+            # users should have valid default group and owner
+            ('USBD',
+             {'field':[
+                {'name':'DEFGRP_ID', 'expect':'GROUP'},
+                {'name':'OWNER_ID', 'expect':'ID'}
+                ]
+             }
+            ),
+            # valid CATEGORY, SECLEVEL and SECLABEL
+            (['DSCAT','GRCAT','GRMEM','USCAT'],
+             {'-class':['SECDATA','SECLABEL'],
+              'field':[
+                {'name':'CATEGORY', 'expect':'CATEGORY'},
+                ]
+             }
+            ),
+            (['DSBD','GRBD','GRMEM','USBD'],
+             {'-class':['SECDATA','SECLABEL'],
+              'field':[
+                {'name':'SECLEVEL', 'expect':'SECLEVEL', 'or':'000'},
+                ]
+             }
+            ),
+            (['DSBD','GRBD','USBD','USTSO'],
+             {'field':[
+                {'name':'SECLABEL', 'expect':'SECLABEL'},
+                ]
+             }
+            )
+        ]
+


### PR DESCRIPTION
msys.datasetPermit('SYS1.**', pattern='G').acl(resolve=True)
shows users with access to SYS1 profiles, whether by user or by group permit

msys.datasetAccess('SYS1.**').acl(sort="access")
shows the normal permits on 1 profile, sorted by descending access (strongest first) as defined in the profile

msys.datasetAccess('SYS1.**').acl(permit=False, admin=True)
shows user IDs with OWNER, group special or CONNECT/JOIN auth, to change access to the data sets

.acl supports 
datasetPermit, datasetAccess, datasetConditionalAccess 
generalPermit, generalAccess, generalConditionalAccess 

No update to README.md yet